### PR TITLE
Updated print and NSURL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ let oauthswift = OAuth1Swift(
 oauthswift.authorizeWithCallbackURL(
     NSURL(string: "oauth-swift://oauth-callback/twitter"),
     success: { credential, response, parameters in
-      println(credential.oauth_token)
-      println(credential.oauth_token_secret)
-      println(parameters["user_id"])
+      print(credential.oauth_token)
+      print(credential.oauth_token_secret)
+      print(parameters["user_id"])
     },
     failure: { error in
       print(error.localizedDescription)
@@ -87,7 +87,7 @@ oauthswift.authorizeWithCallbackURL(
     NSURL(string: "oauth-swift://oauth-callback/instagram"),
     scope: "likes+comments", state:"INSTAGRAM",
     success: { credential, response, parameters in
-      println(credential.oauth_token)
+      print(credential.oauth_token)
     },
     failure: { error in
       print(error.localizedDescription)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ let oauthswift = OAuth1Swift(
     accessTokenUrl:  "https://api.twitter.com/oauth/access_token"
 )
 oauthswift.authorizeWithCallbackURL(
-    NSURL(string: "oauth-swift://oauth-callback/twitter"),
+    NSURL(string: "oauth-swift://oauth-callback/twitter")!,
     success: { credential, response, parameters in
       print(credential.oauth_token)
       print(credential.oauth_token_secret)
@@ -84,7 +84,7 @@ let oauthswift = OAuth2Swift(
     responseType:   "token"
 )
 oauthswift.authorizeWithCallbackURL(
-    NSURL(string: "oauth-swift://oauth-callback/instagram"),
+    NSURL(string: "oauth-swift://oauth-callback/instagram")!,
     scope: "likes+comments", state:"INSTAGRAM",
     success: { credential, response, parameters in
       print(credential.oauth_token)


### PR DESCRIPTION
Updated `println` to `print` since it was replaced in the new versions of Swift 

NSURL in the example needs unwrapped.