### PR TITLE
Update example for fitbit OAuth2 response type

### DIFF
--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -271,7 +271,7 @@ extension ViewController {
             consumerSecret: serviceParameters["consumerSecret"]!,
             authorizeUrl:   "https://www.fitbit.com/oauth2/authorize",
             accessTokenUrl: "https://api.fitbit.com/oauth2/token",
-            responseType:   "code"
+            responseType:   "token"
         )
         oauthswift.accessTokenBasicAuthentification = true
         let state: String = generateStateWithLength(20) as String


### PR DESCRIPTION
Hi,

Running example with `code` config retrieves an error:

`The operation couldn’t be completed. Could not get Access Token``

We need to update response type value to `token` to allow to retrieve this info correctly.