### PR TITLE
fix urlEncodedStringWithEncoding to remove reserved characters

### DIFF
--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -33,7 +33,11 @@ extension String {
 
     func urlEncodedStringWithEncoding(encoding: NSStringEncoding) -> String {
         let originalString: NSString = self
-        let customAllowedSet =  NSCharacterSet(charactersInString:" :/?&=;+!@#$()',*=\"#%/<>?@\\^`{|}").invertedSet
+        // Reserved characters in RFC 3986
+        let genDelims = ":/?#[]@"
+        let subDelims = "!$&'()*+,;="
+        let customAllowedSet = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
+        customAllowedSet.removeCharactersInString("\(genDelims)\(subDelims)")
         let escapedString = originalString.stringByAddingPercentEncodingWithAllowedCharacters(customAllowedSet)
         return escapedString! as String
     }


### PR DESCRIPTION
There is signiture error when parameter value includes line feed code(\n).
So I basically use NSCharacterSet.URLQueryAllowedCharacterSet for stringByAddingPercentEncodingWithAllowedCharacters.
And remove some characters defined as reserved in RFC 3986.

I think there are big changes in urlencoding behavior from existing source code.
So I would appreciate if you could check carefully.

Thank you.