### PR TITLE
URL-Encode square brackets Fix #174

### DIFF
--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -33,7 +33,7 @@ extension String {
 
     func urlEncodedStringWithEncoding(encoding: NSStringEncoding) -> String {
         let originalString: NSString = self
-        let customAllowedSet =  NSCharacterSet(charactersInString:" :/?&=;+!@#$()',*=\"#%/<>?@\\^`{|}").invertedSet
+        let customAllowedSet =  NSCharacterSet(charactersInString:" :/?&=;+!@#$()',*=\"#%/<>?@\\^`{|}[]").invertedSet
         let escapedString = originalString.stringByAddingPercentEncodingWithAllowedCharacters(customAllowedSet)
         return escapedString! as String
     }


### PR DESCRIPTION
I've hit an issue where the OAuth signature was calculated wrongly, which I traced back to some of the parameters of the API that I'm using ([UserVoice](https://developer.uservoice.com/docs/api/reference/)) having parameters such as `object[field]=value` and OAuthSwift didn't escape the square brackets.

I checked this against [the nouncer.com calculator](http://nouncer.com/oauth/signature.html). With my fix, the signature from OAuthSwift matches that, and it's also matching the API that I'm connecting to.
