### PR TITLE
Allow for invalidating notification observers on OAuthSwift objects

### DIFF
--- a/OAuthSwift/OAuthSwift.swift
+++ b/OAuthSwift/OAuthSwift.swift
@@ -53,6 +53,12 @@ public class OAuthSwift: NSObject {
             block(url: urlFromUserInfo)
         }
     }
+	
+	// Clean up state from any existing requests
+	public func invalidate() {
+		NSNotificationCenter.defaultCenter().removeObserver(self.observer)
+		authorize_url_handler = OAuthSwiftOpenURLExternally.sharedInstance
+	}
 
 }
 

--- a/OAuthSwift/OAuthSwift.swift
+++ b/OAuthSwift/OAuthSwift.swift
@@ -56,7 +56,9 @@ public class OAuthSwift: NSObject {
 	
 	// Clean up state from any existing requests
 	public func invalidate() {
-		NSNotificationCenter.defaultCenter().removeObserver(self.observer)
+		if let observer = self.observer {
+			NSNotificationCenter.defaultCenter().removeObserver(observer)
+		}
 		authorize_url_handler = OAuthSwiftOpenURLExternally.sharedInstance
 	}
 


### PR DESCRIPTION
Currently in OAuthSwift it doesn't seem to be possible to retry an OAuth connection. If you attempt to use a brand new OAuthSwift object, the old notifications still fire as there's no way to clean them up.

This addition enables these notification observers to be cleaned up from the old OAuth object before attempting to use another one.

I'd welcome any other suggestions if this is not ideal, or if there's another way to completely retry an OAuth connection without any existing data from the last connection attempt making its way through.