### PR TITLE
Added support for sending response body in error

### DIFF
--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -125,7 +125,11 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                 if (response as? NSHTTPURLResponse)?.statusCode >= 400 {
                     let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
                     let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString! as String)
-                    let userInfo : [NSObject : AnyObject] = [NSLocalizedDescriptionKey: localizedDescription, "Response-Headers": self.response.allHeaderFields]
+                    let userInfo : [NSObject : AnyObject] = [
+                        NSLocalizedDescriptionKey: localizedDescription,
+                        "Response-Headers": self.response.allHeaderFields,
+                        "Response-Body": responseString ?? NSNull()
+                    ]
                     let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
                     self.failureHandler?(error: error)
                     return


### PR DESCRIPTION
This might be quite useful for other people. I need to be able to access the response body when I get 4XX errors from the server, which this now provides via a new field in the userInfo object.