### PR TITLE
made oauth_verifier public on OAuthSwiftCredential

### DIFF
--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -49,7 +49,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     var consumer_secret: String = String()
     public var oauth_token: String = String()
     public var oauth_token_secret: String = String()
-    public var oauth_verifier: String = String()
+    public internal(set) var oauth_verifier: String = String()
     public var version: Version = .OAuth1
     
     override init(){

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -49,7 +49,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     var consumer_secret: String = String()
     public var oauth_token: String = String()
     public var oauth_token_secret: String = String()
-    var oauth_verifier: String = String()
+    public var oauth_verifier: String = String()
     public var version: Version = .OAuth1
     
     override init(){


### PR DESCRIPTION
Hi, 
Thanks for the awesome work again! We found OAuthSwift super useful.

We have been working on a project where the backend requires us to send the "oauth_verifier" to the server after a user has authenticated.
I consulted with the backend guys and they said this requirement is coming from the official Flickr library they're using.
Would it be alright to expose this property as public? Are there any other workarounds we could use to access it without necessarily polluting the public API? Has this been requested before?

Thanks a lot!