### PR TITLE
Add an option to send the OAuth1.0 parameters as request parameters (fix #187)

### DIFF
--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -22,7 +22,7 @@ public class OAuth1Swift: OAuthSwift {
     var access_token_url: String
     
     // MARK: init
-    public init(consumerKey: String, consumerSecret: String, requestTokenUrl: String, authorizeUrl: String, accessTokenUrl: String, paramsLocation : OAuthSwiftHTTPRequest.ParamsLocation){
+    public init(consumerKey: String, consumerSecret: String, requestTokenUrl: String, authorizeUrl: String, accessTokenUrl: String){
         self.consumer_key = consumerKey
         self.consumer_secret = consumerSecret
         self.request_token_url = requestTokenUrl
@@ -30,15 +30,6 @@ public class OAuth1Swift: OAuthSwift {
         self.access_token_url = accessTokenUrl
         super.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
         self.client.credential.version = .OAuth1
-        self.client.paramsLocation = paramsLocation;
-    }
-    
-    public convenience init(consumerKey: String, consumerSecret: String, requestTokenUrl: String, authorizeUrl: String, accessTokenUrl: String) {
-        self.init(consumerKey:consumerKey, consumerSecret: consumerSecret,
-            requestTokenUrl: requestTokenUrl,
-            authorizeUrl: authorizeUrl,
-            accessTokenUrl: accessTokenUrl,
-            paramsLocation: OAuthSwiftHTTPRequest.ParamsLocation.AuthorizationHeader)
     }
 
     public convenience init?(parameters: [String:String]){

--- a/OAuthSwift/OAuth1Swift.swift
+++ b/OAuthSwift/OAuth1Swift.swift
@@ -22,7 +22,7 @@ public class OAuth1Swift: OAuthSwift {
     var access_token_url: String
     
     // MARK: init
-    public init(consumerKey: String, consumerSecret: String, requestTokenUrl: String, authorizeUrl: String, accessTokenUrl: String){
+    public init(consumerKey: String, consumerSecret: String, requestTokenUrl: String, authorizeUrl: String, accessTokenUrl: String, paramsLocation : OAuthSwiftHTTPRequest.ParamsLocation){
         self.consumer_key = consumerKey
         self.consumer_secret = consumerSecret
         self.request_token_url = requestTokenUrl
@@ -30,6 +30,15 @@ public class OAuth1Swift: OAuthSwift {
         self.access_token_url = accessTokenUrl
         super.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
         self.client.credential.version = .OAuth1
+        self.client.paramsLocation = paramsLocation;
+    }
+    
+    public convenience init(consumerKey: String, consumerSecret: String, requestTokenUrl: String, authorizeUrl: String, accessTokenUrl: String) {
+        self.init(consumerKey:consumerKey, consumerSecret: consumerSecret,
+            requestTokenUrl: requestTokenUrl,
+            authorizeUrl: authorizeUrl,
+            accessTokenUrl: accessTokenUrl,
+            paramsLocation: OAuthSwiftHTTPRequest.ParamsLocation.AuthorizationHeader)
     }
 
     public convenience init?(parameters: [String:String]){

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -114,19 +114,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
   
     public func authorizationHeaderForMethod(method: OAuthSwiftHTTPRequest.Method, url: NSURL, parameters: Dictionary<String, AnyObject>, body: NSData? = nil, timestamp: String, nonce: String) -> String {
         assert(self.version == .OAuth1)
-        var authorizationParameters = self.authorizationParameters(body, timestamp: timestamp, nonce: nonce)
-        
-        for (key, value) in parameters {
-            if key.hasPrefix("oauth_") {
-                authorizationParameters.updateValue(value, forKey: key)
-            }
-        }
-        
-        let combinedParameters = authorizationParameters.join(parameters)
-        
-        let finalParameters = combinedParameters
-        
-        authorizationParameters["oauth_signature"] = self.signatureForMethod(method, url: url, parameters: finalParameters)
+        let authorizationParameters = self.authorizationParametersWithSignatureForMethod(method, url: url, parameters: parameters, body: body, timestamp: timestamp, nonce: nonce)
         
         var parameterComponents = authorizationParameters.urlEncodedQueryStringWithEncoding(OAuthSwiftDataEncoding).componentsSeparatedByString("&") as [String]
         parameterComponents.sortInPlace { $0 < $1 }
@@ -140,6 +128,28 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         }
         
         return "OAuth " + headerComponents.joinWithSeparator(", ")
+    }
+    
+    public func authorizationParametersWithSignatureForMethod(method: OAuthSwiftHTTPRequest.Method, url: NSURL, parameters: Dictionary<String, AnyObject>, body: NSData? = nil) -> Dictionary<String, AnyObject> {
+        let timestamp = String(Int64(NSDate().timeIntervalSince1970))
+        let nonce = OAuthSwiftCredential.generateNonce()
+        return self.authorizationParametersWithSignatureForMethod(method, url: url, parameters: parameters, body: body, timestamp: timestamp, nonce: nonce)
+    }
+
+    public func authorizationParametersWithSignatureForMethod(method: OAuthSwiftHTTPRequest.Method, url: NSURL, parameters: Dictionary<String, AnyObject>, body: NSData? = nil, timestamp: String, nonce: String) -> Dictionary<String, AnyObject> {
+        var authorizationParameters = self.authorizationParameters(body, timestamp: timestamp, nonce: nonce)
+        
+        for (key, value) in parameters {
+            if key.hasPrefix("oauth_") {
+                authorizationParameters.updateValue(value, forKey: key)
+            }
+        }
+        
+        let combinedParameters = authorizationParameters.join(parameters)
+        
+        authorizationParameters["oauth_signature"] = self.signatureForMethod(method, url: url, parameters: combinedParameters)
+        
+        return authorizationParameters;
     }
     
     public func authorizationParameters(body: NSData?, timestamp: String, nonce: String) -> Dictionary<String, AnyObject> {

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -60,7 +60,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         self.init(URL: URL, method: .GET, parameters: [:])
     }
 
-    init(URL: NSURL, method: Method, parameters: Dictionary<String, AnyObject>, paramsLocation : ParamsLocation? = .AuthorizationHeader) {
+    init(URL: NSURL, method: Method, parameters: Dictionary<String, AnyObject>, paramsLocation : ParamsLocation = .AuthorizationHeader) {
         self.URL = URL
         self.HTTPMethod = method
         self.headers = [:]
@@ -69,10 +69,10 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         self.timeoutInterval = 60
         self.HTTPShouldHandleCookies = false
         self.responseData = NSMutableData()
-        self.paramsLocation = paramsLocation!
+        self.paramsLocation = paramsLocation
     }
 
-    init(request: NSURLRequest, paramsLocation : ParamsLocation? = .AuthorizationHeader) {
+    init(request: NSURLRequest, paramsLocation : ParamsLocation = .AuthorizationHeader) {
         self.request = request as? NSMutableURLRequest
         self.URL = request.URL!
         self.HTTPMethod = Method(rawValue: request.HTTPMethod ?? "") ?? .GET
@@ -82,7 +82,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         self.timeoutInterval = 60
         self.HTTPShouldHandleCookies = false
         self.responseData = NSMutableData()
-        self.paramsLocation = paramsLocation!
+        self.paramsLocation = paramsLocation
     }
 
     func start() {
@@ -166,7 +166,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         parameters: Dictionary<String, AnyObject>,
         dataEncoding: NSStringEncoding,
         body: NSData? = nil,
-        paramsLocation: ParamsLocation? = .AuthorizationHeader) throws -> NSMutableURLRequest {
+        paramsLocation: ParamsLocation = .AuthorizationHeader) throws -> NSMutableURLRequest {
             let request = NSMutableURLRequest(URL: URL)
             request.HTTPMethod = method.rawValue
             return try setupRequestForOAuth(request,
@@ -184,7 +184,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         parameters: Dictionary<String, AnyObject>,
         dataEncoding: NSStringEncoding,
         body: NSData? = nil,
-        paramsLocation : ParamsLocation? = .AuthorizationHeader) throws -> NSMutableURLRequest {
+        paramsLocation : ParamsLocation = .AuthorizationHeader) throws -> NSMutableURLRequest {
             for (key, value) in headers {
                 request.setValue(value, forHTTPHeaderField: key)
             }
@@ -192,7 +192,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
             let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(dataEncoding))
 
             let finalParameters : Dictionary<String, AnyObject>
-            switch (paramsLocation!) {
+            switch (paramsLocation) {
             case .AuthorizationHeader:
                 finalParameters = parameters.filter { key, _ in !key.hasPrefix("oauth_") }
             case .RequestURIQuery:

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -345,11 +345,23 @@ extension ViewController {
             consumerSecret: serviceParameters["consumerSecret"]!,
             requestTokenUrl: "https://oauth.withings.com/account/request_token",
             authorizeUrl:    "https://oauth.withings.com/account/authorize",
-            accessTokenUrl:  "https://oauth.withings.com/account/access_token"
+            accessTokenUrl:  "https://oauth.withings.com/account/access_token",
+            paramsLocation : .RequestURIQuery
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/withings")!, success: {
             credential, response, parameters in
             self.showTokenAlert(serviceParameters["name"], credential: credential)
+            self.testWithings(oauthswift, userId: parameters["userid"]!)
+            }, failure: { error in
+                print(error.localizedDescription)
+        })
+    }
+    func testWithings(oauthswift: OAuth1Swift, userId : NSString) {
+        oauthswift.client.get("https://wbsapi.withings.net/v2/measure", parameters: ["action":"getactivity", "userid":userId, "date":"2016-02-15"],
+            success: {
+                data, response in
+                let jsonDict: AnyObject! = try? NSJSONSerialization.JSONObjectWithData(data, options: [])
+                print(jsonDict)
             }, failure: { error in
                 print(error.localizedDescription)
         })

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -345,8 +345,7 @@ extension ViewController {
             consumerSecret: serviceParameters["consumerSecret"]!,
             requestTokenUrl: "https://oauth.withings.com/account/request_token",
             authorizeUrl:    "https://oauth.withings.com/account/authorize",
-            accessTokenUrl:  "https://oauth.withings.com/account/access_token",
-            paramsLocation : .RequestURIQuery
+            accessTokenUrl:  "https://oauth.withings.com/account/access_token"
         )
         oauthswift.authorizeWithCallbackURL( NSURL(string: "oauth-swift://oauth-callback/withings")!, success: {
             credential, response, parameters in
@@ -357,6 +356,7 @@ extension ViewController {
         })
     }
     func testWithings(oauthswift: OAuth1Swift, userId : NSString) {
+        oauthswift.client.paramsLocation = .RequestURIQuery
         oauthswift.client.get("https://wbsapi.withings.net/v2/measure", parameters: ["action":"getactivity", "userid":userId, "date":"2016-02-15"],
             success: {
                 data, response in


### PR DESCRIPTION
As described in issue #187, some servers (at least the Withings one) require that the OAuth1.0 parameters are transmitted as query parameters.

As it is not an usual behaviour, I have tried to minimize the changes by using convenience initializers and optionnals parameters with default value.

There is 2 places where the process differs: 
- In OAuthSwiftClient where the oauth parameters are set in the authorization header or in query paremeters
- In OAuthSwiftHTTPRequest where the oauth parameters should not be removed from the query parameters in the new case

