### PR TITLE
OAUTH_APP_EXTENSIONS  inside UIApplication extension (Fixes #193) + remove & from query string 

### DIFF
--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -58,7 +58,8 @@ extension String {
             key = nil
             scanner.scanUpToString(keyValueSeparator, intoString: &key)
             scanner.scanString(keyValueSeparator, intoString: nil)
-
+			key = key?.stringByReplacingOccurrencesOfString("&", withString: "")
+			
             value = nil
             scanner.scanUpToString(elementSeparator, intoString: &value)
             scanner.scanString(elementSeparator, intoString: nil)

--- a/OAuthSwift/UIApplication+OAuthSwift.swift
+++ b/OAuthSwift/UIApplication+OAuthSwift.swift
@@ -11,7 +11,11 @@
 
     extension UIApplication {
         static var topViewController: UIViewController? {
-            return UIApplication.sharedApplication().topViewController
+			#if !OAUTH_APP_EXTENSIONS
+				return UIApplication.sharedApplication().topViewController
+			#else
+				return nil
+			#endif
         }
 
         var topViewController: UIViewController? {


### PR DESCRIPTION
* Make sure OAUTH_APP_EXTENSIONS works inside the UIApplication extension too (Fixes #193)
* Remove &-symbol from keys in query string. Query strings can start with an & so. Before this fix some keys started with an &. 