### PR TITLE
Remove first char from query string when needed

### DIFF
--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -47,9 +47,15 @@ extension String {
     }
 
     func dictionaryBySplitting(elementSeparator: String, keyValueSeparator: String) -> Dictionary<String, String> {
+		
+		var string = self
+		if(hasPrefix(elementSeparator)) {
+			string = String(characters.dropFirst(1))
+		}
+		
         var parameters = Dictionary<String, String>()
 
-        let scanner = NSScanner(string: self)
+        let scanner = NSScanner(string: string)
 
         var key: NSString?
         var value: NSString?


### PR DESCRIPTION
I use OAuthSwift with an OAuth 1 API. The API returns a query string which starts with an &-symbol. Because of this, the first key will be parsed as '&oauth_token'.
This pull request fixes this problem.