### PR TITLE
Custom URI parameter for oauth token

### DIFF
--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -122,13 +122,15 @@ public class OAuthSwiftClient: NSObject {
             case .RequestURIQuery:
                 //Add oauth parameters as request parameters
                 request.parameters += self.credential.authorizationParametersWithSignatureForMethod(method, url: signatureUrl, parameters: signatureParameters, body: body)
+            case .OAuthTokenParameter(let param):
+                //Add oauth token as custom parameter
+                request.parameters[param] = self.credential.oauth_token
             }
             
             if let addHeaders = headers {
                 requestHeaders += addHeaders
             }
             request.headers = requestHeaders
-
             request.dataEncoding = OAuthSwiftDataEncoding
             return request
         }

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -21,8 +21,8 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
         }
     }
     
-    @objc public enum ParamsLocation : Int {
-        case AuthorizationHeader, /*FormEncodedBody,*/ RequestURIQuery
+    public enum ParamsLocation {
+        case AuthorizationHeader, /*FormEncodedBody,*/ RequestURIQuery, OAuthTokenParameter(String)
     }
 
     var URL: NSURL
@@ -195,7 +195,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
             switch (paramsLocation) {
             case .AuthorizationHeader:
                 finalParameters = parameters.filter { key, _ in !key.hasPrefix("oauth_") }
-            case .RequestURIQuery:
+            default:
                 finalParameters = parameters
             }
 

--- a/OAuthSwiftDemo/ViewController.swift
+++ b/OAuthSwiftDemo/ViewController.swift
@@ -415,6 +415,7 @@ extension ViewController {
         })
     }
     func testLinkedin2(oauthswift: OAuth2Swift) {
+        oauthswift.client.paramsLocation = .OAuthTokenParameter("oauth2_access_token")
         oauthswift.client.get("https://api.linkedin.com/v1/people/~?format=json", parameters: [:],
             success: {
                 data, response in


### PR DESCRIPTION
You can chose a custom parameter name for oauth_token.

Inspired by a LinkedIn OAuth common error using the Authorization header.