### PR TITLE
Fixed the encoding to comply with the OAuth 1.0 specification

### DIFF
--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -33,7 +33,7 @@ extension String {
 
     func urlEncodedStringWithEncoding(encoding: NSStringEncoding) -> String {
         let originalString: NSString = self
-        let customAllowedSet =  NSCharacterSet(charactersInString:" :/?&=;+!@#$()',*=\"#%/<>?@\\^`{|}").invertedSet
+        let customAllowedSet =  NSCharacterSet(charactersInString:"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
         let escapedString = originalString.stringByAddingPercentEncodingWithAllowedCharacters(customAllowedSet)
         return escapedString! as String
     }


### PR DESCRIPTION
The OAuth 1.0 specification is very clear about what is allowed:

> - Characters in the unreserved character set as defined by [RFC3986],
Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST NOT be encoded.
> - All other characters MUST be encoded.
(https://tools.ietf.org/html/rfc5849)

I modified the code to better reflect that.