### PR TITLE
Add Goodreads OAuth provider page

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ More examples into demo application: [ViewController.swift](/OAuthSwiftDemo/View
 * [Spotify](https://developer.spotify.com/web-api/authorization-guide/)
 * [Trello](https://developers.trello.com/authorize)
 * [Buffer](https://buffer.com/developers/api/oauth)
+* [Goodreads](https://www.goodreads.com/api/documentation#oauth)
 
 ## Images
 


### PR DESCRIPTION
Saw Goodreads was added, but I saw no provider page in the README. This adds the provider page for Goodreads. :-)