### PR TITLE
[OAuth 2] Start an authorized request by suppling an automatic mechanism of token renewal

### DIFF
--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -90,6 +90,10 @@
 		D20BBB761C2459C300F2B012 /* OAuthSwiftMultipartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20BBB741C2454A900F2B012 /* OAuthSwiftMultipartData.swift */; };
 		D20BBB771C2459CF00F2B012 /* OAuthSwiftMultipartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20BBB741C2454A900F2B012 /* OAuthSwiftMultipartData.swift */; };
 		D20BBB781C2459DB00F2B012 /* OAuthSwiftMultipartData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20BBB741C2454A900F2B012 /* OAuthSwiftMultipartData.swift */; };
+		E5E90A9F1CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E90A9E1CA84E1C005F51BD /* NSDate+OAuthSwift.swift */; };
+		E5E90AA01CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E90A9E1CA84E1C005F51BD /* NSDate+OAuthSwift.swift */; };
+		E5E90AA11CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E90A9E1CA84E1C005F51BD /* NSDate+OAuthSwift.swift */; };
+		E5E90AA21CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E90A9E1CA84E1C005F51BD /* NSDate+OAuthSwift.swift */; };
 		F422B2D91A67B2A20060A70F /* OAuthSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; };
 		F42F57D91A67F2040064249F /* OAuthSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F435027A1A6791B200038A29 /* OAuthSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F435027F1A6791B200038A29 /* OAuthSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = F435027E1A6791B200038A29 /* OAuthSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -204,6 +208,7 @@
 		C4FAE4351C061660000CE669 /* SignTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignTests.swift; sourceTree = "<group>"; };
 		CD08B3AF6A53A4118604A455 /* Pods-OAuthSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OAuthSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D20BBB741C2454A900F2B012 /* OAuthSwiftMultipartData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftMultipartData.swift; sourceTree = "<group>"; };
+		E5E90A9E1CA84E1C005F51BD /* NSDate+OAuthSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+OAuthSwift.swift"; sourceTree = "<group>"; };
 		F43502681A6790EC00038A29 /* OAuth1Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth1Swift.swift; sourceTree = "<group>"; };
 		F43502691A6790EC00038A29 /* OAuth2Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2Swift.swift; sourceTree = "<group>"; };
 		F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftClient.swift; sourceTree = "<group>"; };
@@ -328,6 +333,7 @@
 		C49624741B00F8240010BD09 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				E5E90A9E1CA84E1C005F51BD /* NSDate+OAuthSwift.swift */,
 				F4805E1E1A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift */,
 				F4805E1F1A6BB5DD00F7677E /* NSURL+OAuthSwift.swift */,
 				F4805E201A6BB5DD00F7677E /* String+OAuthSwift.swift */,
@@ -823,6 +829,7 @@
 				C40890CD1C11B38000E3146A /* OAuthSwiftURLHandlerType.swift in Sources */,
 				C40890D01C11B38000E3146A /* SHA1.swift in Sources */,
 				C40890D41C11B38700E3146A /* String+OAuthSwift.swift in Sources */,
+				E5E90AA21CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */,
 				C40890DB1C11D48300E3146A /* OAuthSwift.swift in Sources */,
 				C40890D11C11B38000E3146A /* HMAC.swift in Sources */,
 				C40890CA1C11B38000E3146A /* OAuthSwiftClient.swift in Sources */,
@@ -847,6 +854,7 @@
 				C48B282A1AFA599A00C7DEF6 /* NSURL+OAuthSwift.swift in Sources */,
 				C48B282C1AFA599A00C7DEF6 /* NSData+OAuthSwift.swift in Sources */,
 				C48B28271AFA599A00C7DEF6 /* SHA1.swift in Sources */,
+				E5E90AA01CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */,
 				C40890D91C11D48300E3146A /* OAuthSwift.swift in Sources */,
 				C48B28231AFA599A00C7DEF6 /* OAuthSwiftClient.swift in Sources */,
 				C48B28281AFA599A00C7DEF6 /* HMAC.swift in Sources */,
@@ -890,6 +898,7 @@
 				C4B6EE321BF74CF400443596 /* String+OAuthSwift.swift in Sources */,
 				C4B6EE331BF74CF400443596 /* NSData+OAuthSwift.swift in Sources */,
 				C42D41BD1C1AD11600DEDF53 /* UIApplication+OAuthSwift.swift in Sources */,
+				E5E90AA11CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */,
 				C4B6EE341BF74CF400443596 /* Int+OAuthSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -931,6 +940,7 @@
 				F4805E211A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift in Sources */,
 				F47599B11A79001B004A96C1 /* NSData+OAuthSwift.swift in Sources */,
 				C42D41BC1C1AD11600DEDF53 /* UIApplication+OAuthSwift.swift in Sources */,
+				E5E90A9F1CA84E1C005F51BD /* NSDate+OAuthSwift.swift in Sources */,
 				C496246F1B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OAuthSwift/NSDate+OAuthSwift.swift
+++ b/OAuthSwift/NSDate+OAuthSwift.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension NSDate: Comparable {}
+
+public func == (lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.isEqualToDate(rhs)
+}
+
+public func <= (lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs < rhs || lhs == rhs
+}
+
+public func >= (lhs: NSDate, rhs: NSDate) -> Bool {
+    return rhs <= lhs
+}
+
+public func < (lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.compare(rhs) == NSComparisonResult.OrderedAscending
+}
+
+public func > (lhs: NSDate, rhs: NSDate) -> Bool {
+    return rhs < lhs
+}

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -88,12 +88,12 @@ public class OAuth2Swift: OAuthSwift {
                 if !self.allowMissingStateCheck {
                     guard let responseState = responseParameters["state"] else {
                         let errorInfo = [NSLocalizedDescriptionKey: "Missing state"]
-                        failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+                        failure(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.MissingStateError.rawValue, userInfo: errorInfo))
                         return
                     }
                     if responseState != state {
                         let errorInfo = [NSLocalizedDescriptionKey: "state not equals"]
-                        failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+                        failure(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.StateNotEqualError.rawValue, userInfo: errorInfo))
                         return
                     }
                 }
@@ -102,11 +102,11 @@ public class OAuth2Swift: OAuthSwift {
             }
             else if let error = responseParameters["error"], error_description = responseParameters["error_description"] {
                 let errorInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString(error, comment: error_description)]
-                failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+                failure(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.GeneralError.rawValue, userInfo: errorInfo))
             }
             else {
                 let errorInfo = [NSLocalizedDescriptionKey: "No access_token, no code and no error provided by server"]
-                failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+                failure(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.ServerError.rawValue, userInfo: errorInfo))
             }
         }
 
@@ -132,7 +132,7 @@ public class OAuth2Swift: OAuthSwift {
         }
         else {
             let errorInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString("Failed to create URL", comment: "\(urlString) or \(queryString) not convertible to URL, please check encoding")]
-            failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+            failure(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.EncodingError.rawValue, userInfo: errorInfo))
         }
     }
     
@@ -160,7 +160,7 @@ public class OAuth2Swift: OAuthSwift {
             guard let accessToken = responseParameters["access_token"] else {
                 if let failure = failure {
                     let errorInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString("Could not get Access Token", comment: "Due to an error in the OAuth2 process, we couldn't get a valid token.")]
-                    failure(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+                    failure(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.ServerError.rawValue, userInfo: errorInfo))
                 }
                 return
             }
@@ -193,7 +193,7 @@ public class OAuth2Swift: OAuthSwift {
             }
             else {
                 let errorInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString("access token url not defined", comment: "access token url not defined with code type auth")]
-                failure?(error: NSError(domain: OAuthSwiftErrorDomain, code: -1, userInfo: errorInfo))
+                failure?(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.GeneralError.rawValue, userInfo: errorInfo))
             }
         }
     }

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -167,6 +167,11 @@ public class OAuth2Swift: OAuthSwift {
             if let refreshToken:String = responseParameters["refresh_token"] {
                 self.client.credential.oauth_refresh_token = refreshToken.safeStringByRemovingPercentEncoding
             }
+            
+            if let expiresIn:String = responseParameters["expires_in"], offset = Double(expiresIn)  {
+                self.client.credential.oauth_token_expires_date = NSDate(timeInterval: offset, sinceDate: NSDate())
+            }
+            
             self.client.credential.oauth_token = accessToken.safeStringByRemovingPercentEncoding
             success(credential: self.client.credential, response: response, parameters: responseParameters)
         }

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -183,7 +183,7 @@ public class OAuth2Swift: OAuthSwift {
             }
             
             if let expiresIn:String = responseParameters["expires_in"], offset = Double(expiresIn)  {
-                self.client.credential.oauth_token_expires_date = NSDate(timeInterval: offset, sinceDate: NSDate())
+                self.client.credential.oauth_token_expires_at = NSDate(timeInterval: offset, sinceDate: NSDate())
             }
             
             self.client.credential.oauth_token = accessToken.safeStringByRemovingPercentEncoding

--- a/OAuthSwift/OAuthSwift.swift
+++ b/OAuthSwift/OAuthSwift.swift
@@ -67,3 +67,12 @@ public class OAuthSwift: NSObject {
 
 // MARK: OAuthSwift errors
 public let OAuthSwiftErrorDomain = "oauthswift.error"
+
+public enum OAuthSwiftErrorCode: Int {
+    case GeneralError = -1
+    case TokenExpiredError = -2
+    case MissingStateError = -3
+    case StateNotEqualError = -4
+    case ServerError = -5
+    case EncodingError = -6
+}

--- a/OAuthSwift/OAuthSwift.swift
+++ b/OAuthSwift/OAuthSwift.swift
@@ -23,7 +23,8 @@ public class OAuthSwift: NSObject {
     // MARK: callback alias
     public typealias TokenSuccessHandler = (credential: OAuthSwiftCredential, response: NSURLResponse?, parameters: Dictionary<String, String>) -> Void
     public typealias FailureHandler = (error: NSError) -> Void
-
+    public typealias TokenRenewedHandler = (credential: OAuthSwiftCredential) -> Void
+    
     // MARK: init
     init(consumerKey: String, consumerSecret: String) {
         self.client = OAuthSwiftClient(consumerKey: consumerKey, consumerSecret: consumerSecret)

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -51,10 +51,10 @@ public class OAuthSwiftClient: NSObject {
     public func patch(urlString: String, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         self.request(urlString, method: .PATCH, parameters: parameters, headers: headers,success: success, failure: failure)
     }
-
-    public func request(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    
+    public func request(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         
-        if self.credential.isTokenExpired() {
+        if checkTokenExpiration && self.credential.isTokenExpired()  {
             let errorInfo = [NSLocalizedDescriptionKey: NSLocalizedString("The provided token is expired.", comment:"Token expired, retrieve new token by using the refresh token")]
             
             if let failureHandler = failure {
@@ -198,8 +198,8 @@ public class OAuthSwiftClient: NSObject {
         data.appendData(endingData)
         return data
     }
-
-    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, multiparts: Array<OAuthSwiftMultipartData> = [], success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    
+    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, multiparts: Array<OAuthSwiftMultipartData> = [], checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         
         if let request = makeRequest(url, method: method, parameters: parameters) {
 

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -53,6 +53,17 @@ public class OAuthSwiftClient: NSObject {
     }
 
     public func request(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+        
+        if self.credential.isTokenExpired() {
+            let errorInfo = [NSLocalizedDescriptionKey: NSLocalizedString("The provided token is expired.", comment:"Token expired, retrieve new token by using the refresh token")]
+            
+            if let failureHandler = failure {
+                failureHandler(error: NSError(domain: OAuthSwiftErrorDomain, code: OAuthSwiftErrorCode.TokenExpiredError.rawValue, userInfo: errorInfo))
+            }
+            
+            return
+        }
+        
         if let request = makeRequest(url, method: method, parameters: parameters, headers: headers) {
             
             request.successHandler = success

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -50,7 +50,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     public var oauth_token: String = String()
     public var oauth_refresh_token: String = String()
     public var oauth_token_secret: String = String()
-    public var oauth_token_expires_date: NSDate = NSDate()
+    public var oauth_token_expires_date: NSDate? = nil
     public internal(set) var oauth_verifier: String = String()
     public var version: Version = .OAuth1
     
@@ -87,7 +87,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         self.oauth_refresh_token = (decoder.decodeObjectForKey(CodingKeys.oauthRefreshToken) as? String) ?? String()
         self.oauth_token_secret = (decoder.decodeObjectForKey(CodingKeys.oauthTokenSecret) as? String) ?? String()
         self.oauth_verifier = (decoder.decodeObjectForKey(CodingKeys.oauthVerifier) as? String) ?? String()
-        self.oauth_token_expires_date = (decoder.decodeObjectForKey(CodingKeys.oauthTokenExpiresDate) as? NSDate) ?? NSDate()
+        self.oauth_token_expires_date = (decoder.decodeObjectForKey(CodingKeys.oauthTokenExpiresDate) as? NSDate)
     }
     
     public func encodeWithCoder(coder: NSCoder) {
@@ -200,5 +200,14 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
 
         let sha1 = self.version.signatureMethod.sign(key, message: msg)!
         return sha1.base64EncodedStringWithOptions([])
+    }
+    
+    public func isTokenExpired() -> Bool {
+        if let expiresDate = oauth_token_expires_date {
+            return expiresDate >= NSDate()
+        }
+        
+        // If no expires date is available we assume the token is still valid since it doesn't have an expiration date to check with.
+        return false;
     }
 }

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -50,7 +50,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     public var oauth_token: String = String()
     public var oauth_refresh_token: String = String()
     public var oauth_token_secret: String = String()
-    public var oauth_token_expires_date: NSDate? = nil
+    public var oauth_token_expires_at: NSDate? = nil
     public internal(set) var oauth_verifier: String = String()
     public var version: Version = .OAuth1
     
@@ -72,7 +72,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         static let consumerSecret = base + "consumer_secret"
         static let oauthToken = base + "oauth_token"
         static let oauthRefreshToken = base + "oauth_refresh_token"
-        static let oauthTokenExpiresDate = base + "oauth_token_expires_date"
+        static let oauthTokenExpiresAt = base + "oauth_token_expires_at"
         static let oauthTokenSecret = base + "oauth_token_secret"
         static let oauthVerifier = base + "oauth_verifier"
     }
@@ -87,7 +87,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         self.oauth_refresh_token = (decoder.decodeObjectForKey(CodingKeys.oauthRefreshToken) as? String) ?? String()
         self.oauth_token_secret = (decoder.decodeObjectForKey(CodingKeys.oauthTokenSecret) as? String) ?? String()
         self.oauth_verifier = (decoder.decodeObjectForKey(CodingKeys.oauthVerifier) as? String) ?? String()
-        self.oauth_token_expires_date = (decoder.decodeObjectForKey(CodingKeys.oauthTokenExpiresDate) as? NSDate)
+        self.oauth_token_expires_at = (decoder.decodeObjectForKey(CodingKeys.oauthTokenExpiresAt) as? NSDate)
     }
     
     public func encodeWithCoder(coder: NSCoder) {
@@ -97,7 +97,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         coder.encodeObject(self.oauth_refresh_token, forKey: CodingKeys.oauthRefreshToken)
         coder.encodeObject(self.oauth_token_secret, forKey: CodingKeys.oauthTokenSecret)
         coder.encodeObject(self.oauth_verifier, forKey: CodingKeys.oauthVerifier)
-        coder.encodeObject(self.oauth_token_expires_date, forKey: CodingKeys.oauthTokenExpiresDate)
+        coder.encodeObject(self.oauth_token_expires_at, forKey: CodingKeys.oauthTokenExpiresAt)
     }
     // } // End NSCoding extension
 
@@ -203,8 +203,8 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     }
     
     public func isTokenExpired() -> Bool {
-        if let expiresDate = oauth_token_expires_date {
-            return expiresDate >= NSDate()
+        if let expiresDate = oauth_token_expires_at {
+            return expiresDate <= NSDate()
         }
         
         // If no expires date is available we assume the token is still valid since it doesn't have an expiration date to check with.

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -50,6 +50,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     public var oauth_token: String = String()
     public var oauth_refresh_token: String = String()
     public var oauth_token_secret: String = String()
+    public var oauth_token_expires_date: NSDate = NSDate()
     public internal(set) var oauth_verifier: String = String()
     public var version: Version = .OAuth1
     
@@ -71,6 +72,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         static let consumerSecret = base + "consumer_secret"
         static let oauthToken = base + "oauth_token"
         static let oauthRefreshToken = base + "oauth_refresh_token"
+        static let oauthTokenExpiresDate = base + "oauth_token_expires_date"
         static let oauthTokenSecret = base + "oauth_token_secret"
         static let oauthVerifier = base + "oauth_verifier"
     }
@@ -85,6 +87,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         self.oauth_refresh_token = (decoder.decodeObjectForKey(CodingKeys.oauthRefreshToken) as? String) ?? String()
         self.oauth_token_secret = (decoder.decodeObjectForKey(CodingKeys.oauthTokenSecret) as? String) ?? String()
         self.oauth_verifier = (decoder.decodeObjectForKey(CodingKeys.oauthVerifier) as? String) ?? String()
+        self.oauth_token_expires_date = (decoder.decodeObjectForKey(CodingKeys.oauthTokenExpiresDate) as? NSDate) ?? NSDate()
     }
     
     public func encodeWithCoder(coder: NSCoder) {
@@ -94,6 +97,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         coder.encodeObject(self.oauth_refresh_token, forKey: CodingKeys.oauthRefreshToken)
         coder.encodeObject(self.oauth_token_secret, forKey: CodingKeys.oauthTokenSecret)
         coder.encodeObject(self.oauth_verifier, forKey: CodingKeys.oauthVerifier)
+        coder.encodeObject(self.oauth_token_expires_date, forKey: CodingKeys.oauthTokenExpiresDate)
     }
     // } // End NSCoding extension
 


### PR DESCRIPTION
# Summary

As described in OAuth 2 documentation, the access token has an expiration date. The duration of an access token, together with a refresh token, is provided when the user retrieves a new access token.

This PR aims to:

* properly store the information about the expiration of a retrieved access token
* expose, in the OAuth 2 client, a convenience mechanism to automatically renew an expired token by using the `refresh token`.
* improve error handling by using a convenience enum struct to store all error codes

# Why?

I'm working on a [library](https://www.github.com/fabiomassimo/GoogleAuthenticator) that helps developers to easily access Google services. I found in OAuthSwift a perfect fit for implementing the OAuth 2 process but I wanted to extend its capability with a solid mechanism of access token automatic renewal only based on the access token expiration.

# How would I use it?

To kick off a request that needs to be authorized simply call, on a OAuth 2 client, the following method:

```swift
oauthClient = OAuth2Swift(consumerKey: consumerKey, consumerSecret: consumerSecret, authorizeUrl: AuthenticationConstants.AuthorizeUrl.rawValue, accessTokenUrl: AuthenticationConstants.AccessTokensUrl.rawValue, responseType: AuthenticationConstants.ResponseType.rawValue)

oauthClient.startAuthorizedRequest(urlString, method: .GET, parameters: parameters, headers: headers, onTokenRenewal: { (credential) in
           // Convenience fallback to store new credential somewhere safe (i.e. the keychain)
            do {
                try self.credential.storeOAuthCredential(credential)
            } catch {
                failure(error: error as NSError)
            }
        }, success: success, failure: failure)
```