### PR TITLE
Fixed Swift 2.2 build warnings

### DIFF
--- a/OAuthSwift/SHA1.swift
+++ b/OAuthSwift/SHA1.swift
@@ -58,8 +58,6 @@ class SHA1 {
         var leftMessageBytes = tmpMessage.length
         var i = 0;
         while i < tmpMessage.length {
-            i = i + chunkSizeBytes
-            leftMessageBytes -= chunkSizeBytes
             let chunk = tmpMessage.subdataWithRange(NSRange(location: i, length: min(chunkSizeBytes,leftMessageBytes)))
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15, big-endian
             // Extend the sixteen 32-bit words into eighty 32-bit words:
@@ -123,6 +121,9 @@ class SHA1 {
             hh[2] = (hh[2] &+ C) & 0xffffffff
             hh[3] = (hh[3] &+ D) & 0xffffffff
             hh[4] = (hh[4] &+ E) & 0xffffffff
+			
+            i = i + chunkSizeBytes
+            leftMessageBytes -= chunkSizeBytes
         }
         
         // Produce the final hash value (big-endian) as a 160 bit number:

--- a/OAuthSwift/SHA1.swift
+++ b/OAuthSwift/SHA1.swift
@@ -56,7 +56,8 @@ class SHA1 {
         // Process the message in successive 512-bit chunks:
         let chunkSizeBytes = 512 / 8 // 64
         var leftMessageBytes = tmpMessage.length
-        for var i in 0..<tmpMessage.length {
+        var i = 0;
+        while i < tmpMessage.length {
             i = i + chunkSizeBytes
             leftMessageBytes -= chunkSizeBytes
             let chunk = tmpMessage.subdataWithRange(NSRange(location: i, length: min(chunkSizeBytes,leftMessageBytes)))

--- a/OAuthSwift/SHA1.swift
+++ b/OAuthSwift/SHA1.swift
@@ -56,7 +56,9 @@ class SHA1 {
         // Process the message in successive 512-bit chunks:
         let chunkSizeBytes = 512 / 8 // 64
         var leftMessageBytes = tmpMessage.length
-        for var i = 0; i < tmpMessage.length; i = i + chunkSizeBytes, leftMessageBytes -= chunkSizeBytes {
+        for var i in 0..<tmpMessage.length {
+            i = i + chunkSizeBytes
+            leftMessageBytes -= chunkSizeBytes
             let chunk = tmpMessage.subdataWithRange(NSRange(location: i, length: min(chunkSizeBytes,leftMessageBytes)))
             // break chunk into sixteen 32-bit words M[j], 0 ≤ j ≤ 15, big-endian
             // Extend the sixteen 32-bit words into eighty 32-bit words:

--- a/OAuthSwift/String+OAuthSwift.swift
+++ b/OAuthSwift/String+OAuthSwift.swift
@@ -26,8 +26,7 @@ extension String {
         get {
             let startIndex = self.startIndex.advancedBy(r.startIndex)
             let endIndex = startIndex.advancedBy(r.endIndex - r.startIndex)
-            
-            return self[Range(start: startIndex, end: endIndex)]
+            return self[startIndex..<endIndex]
         }
     }
 

--- a/OAuthSwift/Utils.swift
+++ b/OAuthSwift/Utils.swift
@@ -41,7 +41,7 @@ func reverseBytes(value: UInt32) -> UInt32 {
 public func generateStateWithLength (len : Int) -> NSString {
     let letters : NSString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
     let randomString : NSMutableString = NSMutableString(capacity: len)
-    for (var i=0; i < len; i++){
+    for _ in 0..<len {
         let length = UInt32 (letters.length)
         let rand = arc4random_uniform(length)
         randomString.appendFormat("%C", letters.characterAtIndex(Int(rand)))


### PR DESCRIPTION
This change fixes build warnings in the OAuthSwift target when using the latest version of Xcode.