### PR TITLE
Provide a method on OAuthSwiftClient that accepts a plain NSURLRequest Fix #212.

### DIFF
--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -74,14 +74,16 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
     }
 
     init(request: NSURLRequest, paramsLocation : ParamsLocation = .AuthorizationHeader) {
-        self.request = request as? NSMutableURLRequest
+        self.request = request.mutableCopy() as? NSMutableURLRequest
+
         self.URL = request.URL!
         self.HTTPMethod = Method(rawValue: request.HTTPMethod ?? "") ?? .GET
-        self.headers = [:]
+        self.headers = request.allHTTPHeaderFields ?? [:]
         self.parameters = [:]
+        self.HTTPBody = request.HTTPBody
         self.dataEncoding = NSUTF8StringEncoding
-        self.timeoutInterval = 60
-        self.HTTPShouldHandleCookies = false
+        self.timeoutInterval = request.timeoutInterval
+        self.HTTPShouldHandleCookies = request.HTTPShouldHandleCookies
         self.responseData = NSMutableData()
         self.paramsLocation = paramsLocation
     }

--- a/OAuthSwiftTests/OAuthSwiftClientTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftClientTests.swift
@@ -29,6 +29,13 @@ class OAuthSwiftClientTests: XCTestCase {
         testMakeRequest(url, ["a":"a", "b":"b"], url,   ["a":"a", "b":"b"])
     }
     
+    func testMakeRequestViaNSURLRequest() {
+        testMakeNSURLRequest(.GET, url)
+        testMakeNSURLRequest(.POST, url)
+        testMakeNSURLRequest(.GET, url + "?a=a")
+        testMakeNSURLRequest(.GET, url + "?a=a&b=b")
+    }
+
     /*func testMakeRequestURLWithQuery() { // deprecated test if no url change
         testMakeRequest("\(url)?a=a", emptyParameters, url, ["a":"a"])
         testMakeRequest("\(url)?a=a&b=b", emptyParameters, url,   ["a":"a", "b":"b"])
@@ -61,6 +68,26 @@ class OAuthSwiftClientTests: XCTestCase {
 
             XCTAssertEqualURL(urlFromRequest.URL!, url!)
             
+        } catch let e {
+            XCTFail("\(e)")
+        }
+    }
+
+    func testMakeNSURLRequest(method: OAuthSwiftHTTPRequest.Method,_ urlString: String) {
+
+        let url = NSURL(string: urlString)!
+        let nsURLRequest = NSMutableURLRequest(URL: url)
+        nsURLRequest.HTTPMethod = method.rawValue
+
+        let request = client.makeRequest(nsURLRequest)
+
+        XCTAssertEqual(request.URL, url)
+        XCTAssertEqual(request.HTTPMethod, method)
+        XCTAssertEqualDictionaries(request.parameters as! [String:String], [:])
+
+        do {
+            let urlFromRequest = try request.makeRequest()
+            XCTAssertEqualURL(urlFromRequest.URL!, url)
         } catch let e {
             XCTFail("\(e)")
         }

--- a/OAuthSwiftTests/OAuthSwiftRequestTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftRequestTests.swift
@@ -94,4 +94,33 @@ class OAuthSwiftRequestTests: XCTestCase {
 		oAuthSwiftHTTPRequest.cancel()
 		waitForExpectationsWithTimeout(DefaultTimeout, handler: nil)
 	}
+
+	func testCreationFromNSURLRequest() {
+		let urlWithoutQueryString = NSURL(string: "www.example.com")!
+		let queryParams = ["a":"123", "b": "", "complex param":"ha öäü ?$"]
+		let headers = ["SomeHeader":"With a value"]
+		let method = OAuthSwiftHTTPRequest.Method.PUT
+		let bodyText = "Test Body"
+		let timeout: NSTimeInterval = 78
+
+		let urlComps = NSURLComponents(URL: urlWithoutQueryString, resolvingAgainstBaseURL: false)
+		urlComps?.queryItems = queryParams.keys.map { NSURLQueryItem(name: $0, value: queryParams[$0]) }
+		let urlWithQueryString = urlComps!.URL!
+		let request = NSMutableURLRequest(URL: urlWithQueryString)
+		request.allHTTPHeaderFields = headers
+		request.HTTPMethod = method.rawValue
+		request.HTTPBody = bodyText.dataUsingEncoding(OAuthSwiftDataEncoding)
+		request.timeoutInterval = timeout
+		request.HTTPShouldHandleCookies = true
+
+		let oauthRequest = OAuthSwiftHTTPRequest(request: request)
+
+		XCTAssertEqualURL(oauthRequest.URL, urlWithQueryString)
+		XCTAssertEqualDictionaries(oauthRequest.parameters as! [String:String], [:])
+		XCTAssertEqualDictionaries(oauthRequest.headers, headers)
+		XCTAssertEqual(oauthRequest.HTTPMethod, method)
+		XCTAssertEqual(String(data: oauthRequest.HTTPBody!, encoding:OAuthSwiftDataEncoding)!, bodyText)
+		XCTAssertEqual(oauthRequest.timeoutInterval, timeout)
+		XCTAssertTrue(oauthRequest.HTTPShouldHandleCookies)
+	}
 }


### PR DESCRIPTION
Added a method on OAuthSwiftClient that accepts a plain NSURLRequest, creates an OAuthSwiftHTTPRequest object with it and starts that request as usually, like discussed in #212.

