### PR TITLE
Add the ability to use custom headers for OAuth 2.0

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -25,6 +25,19 @@ public class OAuth2Swift: OAuthSwift {
     var content_type: String?
     
     // MARK: init
+    public convenience init(consumerKey: String, consumerSecret: String, authorizeUrl: String, accessTokenUrl: String, responseType: String,  headers: [String: String]?){
+      self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, authorizeUrl: authorizeUrl, responseType: responseType)
+      self.access_token_url = accessTokenUrl
+      self.client.credential.oauth2_headers = headers
+    }
+    
+    public convenience init(consumerKey: String, consumerSecret: String, authorizeUrl: String, accessTokenUrl: String, responseType: String, contentType: String,  headers: [String: String]?){
+      self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, authorizeUrl: authorizeUrl, responseType: responseType)
+      self.access_token_url = accessTokenUrl
+      self.content_type = contentType
+      self.client.credential.oauth2_headers = headers
+    }
+  
     public convenience init(consumerKey: String, consumerSecret: String, authorizeUrl: String, accessTokenUrl: String, responseType: String){
         self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, authorizeUrl: authorizeUrl, responseType: responseType)
         self.access_token_url = accessTokenUrl

--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -51,6 +51,7 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
     public var oauth_refresh_token: String = String()
     public var oauth_token_secret: String = String()
     public var oauth_token_expires_at: NSDate? = nil
+    public var oauth2_headers:[String: String]?
     public internal(set) var oauth_verifier: String = String()
     public var version: Version = .OAuth1
     
@@ -106,6 +107,9 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         case .OAuth1:
             return ["Authorization": self.authorizationHeaderForMethod(method, url: url, parameters: parameters, body: body)]
         case .OAuth2:
+            if let headers = oauth2_headers {
+              return headers
+            }
             return self.oauth_token.isEmpty ? [:] : ["Authorization": "Bearer \(self.oauth_token)"]
         }
     }


### PR DESCRIPTION
Some 3rd party APIs that use OAuth 2.0 sometimes require specific headers. For example: Map My Run (https://developer.underarmour.com/docs/v71_OAuth_2_Intro). 

Therefore to tailor to a broad range of APIs, the following pull request adds the ability to init an OAuth2Swift object with custom headers. If the custom headers are found, the OAuthSwiftCredential uses those instead of the default. 

To make it possible to include custom headers, Inside the OAuth2Swift class, two public convenience initializers where added. 

The following approach is one of many ways to add the ability for a user of this library to implement custom headers. If the following style is not regarded as acceptable, I'm very open to other means. I am mainly submitting this PR in hopes that the creator and contributors will acknowledge that freedom of allowing one to provide custom headers could allow many more possibilities when using this library.

This branch has been tested with MapMyRun and Fitbit2. I realize that Fitbit2 already worked out of the box, but wanted to test with more than one API.
