### PR TITLE
Ability to specify body data for PUT request

### DIFF
--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -40,8 +40,8 @@ public class OAuthSwiftClient: NSObject {
         self.request(urlString, method: .POST, parameters: parameters, headers: headers, success: success, failure: failure)
     }
 
-    public func put(urlString: String, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
-        self.request(urlString, method: .PUT, parameters: parameters, headers: headers,success: success, failure: failure)
+    public func put(urlString: String, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, body: NSData? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+        self.request(urlString, method: .PUT, parameters: parameters, headers: headers, body: body, success: success, failure: failure)
     }
 
     public func delete(urlString: String, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
@@ -52,7 +52,7 @@ public class OAuthSwiftClient: NSObject {
         self.request(urlString, method: .PATCH, parameters: parameters, headers: headers,success: success, failure: failure)
     }
     
-    public func request(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    public func request(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, body: NSData? = nil, checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         
         if checkTokenExpiration && self.credential.isTokenExpired()  {
             let errorInfo = [NSLocalizedDescriptionKey: NSLocalizedString("The provided token is expired.", comment:"Token expired, retrieve new token by using the refresh token")]
@@ -64,8 +64,7 @@ public class OAuthSwiftClient: NSObject {
             return
         }
         
-        if let request = makeRequest(url, method: method, parameters: parameters, headers: headers) {
-            
+        if let request = makeRequest(url, method: method, parameters: parameters, headers: headers, body: body) {
             request.successHandler = success
             request.failureHandler = failure
             request.start()
@@ -77,7 +76,7 @@ public class OAuthSwiftClient: NSObject {
         return makeOAuthSwiftHTTPRequest(request)
     }
 
-    public func makeRequest(urlString: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil) -> OAuthSwiftHTTPRequest? {
+    public func makeRequest(urlString: String, method: OAuthSwiftHTTPRequest.Method, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, body: NSData? = nil) -> OAuthSwiftHTTPRequest? {
         guard let url = NSURL(string: urlString) else {
             return nil
         }
@@ -85,6 +84,9 @@ public class OAuthSwiftClient: NSObject {
         let request = OAuthSwiftHTTPRequest(URL: url, method: method, parameters: parameters, paramsLocation: self.paramsLocation)
         if let addHeaders = headers {
             request.headers = addHeaders
+        }
+        if let addBody = body {
+            request.HTTPBody = addBody
         }
         return makeOAuthSwiftHTTPRequest(request)
     }

--- a/OAuthSwiftTests/OAuthSwiftClientTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftClientTests.swift
@@ -53,7 +53,10 @@ class OAuthSwiftClientTests: XCTestCase {
         testMakeRequest(.GET, url:"\(url)?a=a&b=b", ["c":"c"], "\(url)?a=a&b=b&c=c")
     }
     
-    
+    func testMakePUTRequestWithBody() {
+        testMakeRequestWithBody(.PUT, url:url, emptyParameters, url, "BodyContent".dataUsingEncoding(NSUTF8StringEncoding)!)
+    }
+
     func testMakeRequest(method: OAuthSwiftHTTPRequest.Method, url: String,_ parameters: [String:String],_ expectedURL: String, _ expectedBodyJSONDictionary: [String:String]? = nil) {
 
         let request = client.makeRequest(url, method: method, parameters: parameters, headers: ["Content-Type": "application/json"])!
@@ -73,6 +76,15 @@ class OAuthSwiftClientTests: XCTestCase {
         } catch let e {
             XCTFail("\(e)")
         }
+    }
+
+    func testMakeRequestWithBody(method: OAuthSwiftHTTPRequest.Method, url: String, _ parameters: [String:String], _ expectedURL: String, _ expectedBody: NSData) {
+        let request = client.makeRequest(url, method: method, parameters: parameters, headers: ["Content-Type": "foobar"], body: expectedBody)!
+
+        XCTAssertEqual(request.URL, NSURL(string: url)!)
+        XCTAssertEqual(request.HTTPMethod, method)
+        XCTAssertEqualDictionaries(request.parameters as! [String:String], parameters)
+        XCTAssertEqual(request.HTTPBody, expectedBody)
     }
 
     func testMakeNSURLRequest(method: OAuthSwiftHTTPRequest.Method,_ urlString: String) {


### PR DESCRIPTION
* Added an optional "body" parameter to the put method and request method
* Added setting the HTTP Body property to the value passed in to the createRequest method
* Added unit test for making sure the body is set

We have a use case where we need to make a PUT request with data in the body of the request. We couldn't find any publicly accessible way to do this currently, so recommending adding the ability to pass body data in to the request methods. 