### PR TITLE
Ability to provide headers for a multi-part request

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -70,7 +70,7 @@ public class OAuth2Swift: OAuthSwift {
     }
 
     // MARK: functions
-    public func authorizeWithCallbackURL(callbackURL: NSURL, scope: String, state: String, params: [String: String] = [String: String](), success: TokenSuccessHandler, failure: ((error: NSError) -> Void)) {
+    public func authorizeWithCallbackURL(callbackURL: NSURL, scope: String, state: String, params: [String: String] = [String: String](), headers: [String:String]? = nil, success: TokenSuccessHandler, failure: ((error: NSError) -> Void)) {
         
          self.observeCallback { [unowned self] url in
             var responseParameters = [String: String]()
@@ -98,7 +98,7 @@ public class OAuth2Swift: OAuthSwift {
                     }
                 }
                 self.postOAuthAccessTokenWithRequestTokenByCode(code.safeStringByRemovingPercentEncoding,
-                    callbackURL:callbackURL, success: success, failure: failure)
+                    callbackURL:callbackURL, headers: headers , success: success, failure: failure)
             }
             else if let error = responseParameters["error"], error_description = responseParameters["error_description"] {
                 let errorInfo = [NSLocalizedFailureReasonErrorKey: NSLocalizedString(error, comment: error_description)]
@@ -136,7 +136,7 @@ public class OAuth2Swift: OAuthSwift {
         }
     }
     
-    func postOAuthAccessTokenWithRequestTokenByCode(code: String, callbackURL: NSURL, success: TokenSuccessHandler, failure: FailureHandler?) {
+    func postOAuthAccessTokenWithRequestTokenByCode(code: String, callbackURL: NSURL, headers: [String:String]? = nil, success: TokenSuccessHandler, failure: FailureHandler?) {
         var parameters = Dictionary<String, AnyObject>()
         parameters["client_id"] = self.consumer_key
         parameters["client_secret"] = self.consumer_secret
@@ -144,20 +144,20 @@ public class OAuth2Swift: OAuthSwift {
         parameters["grant_type"] = "authorization_code"
         parameters["redirect_uri"] = callbackURL.absoluteString.safeStringByRemovingPercentEncoding
 
-        requestOAuthAccessTokenWithParameters(parameters, success: success, failure: failure)
+        requestOAuthAccessTokenWithParameters(parameters, headers: headers, success: success, failure: failure)
     }
     
-    func renewAccesstokenWithRefreshToken(refreshToken: String, success: TokenSuccessHandler, failure: FailureHandler?) {
+    func renewAccesstokenWithRefreshToken(refreshToken: String, headers: [String:String]? = nil, success: TokenSuccessHandler, failure: FailureHandler?) {
         var parameters = Dictionary<String, AnyObject>()
         parameters["client_id"] = self.consumer_key
         parameters["client_secret"] = self.consumer_secret
         parameters["refresh_token"] = refreshToken
         parameters["grant_type"] = "refresh_token"
         
-        requestOAuthAccessTokenWithParameters(parameters, success: success, failure: failure)
+        requestOAuthAccessTokenWithParameters(parameters, headers: headers, success: success, failure: failure)
     }
     
-    private func requestOAuthAccessTokenWithParameters(parameters: [String : AnyObject], success: TokenSuccessHandler, failure: FailureHandler?) {
+    private func requestOAuthAccessTokenWithParameters(parameters: [String : AnyObject], headers: [String: String]? = nil, success: TokenSuccessHandler, failure: FailureHandler?) {
         let successHandler: OAuthSwiftHTTPRequest.SuccessHandler = { [unowned self]
             data, response in
             let responseJSON: AnyObject? = try? NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.MutableContainers)
@@ -192,7 +192,7 @@ public class OAuth2Swift: OAuthSwift {
 
         if self.content_type == "multipart/form-data" {
             // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
-            self.client.postMultiPartRequest(self.access_token_url!, method: .POST, parameters: parameters, headers: [:], checkTokenExpiration: false, success: successHandler, failure: failure)
+            self.client.postMultiPartRequest(self.access_token_url!, method: .POST, parameters: parameters, headers: headers, checkTokenExpiration: false, success: successHandler, failure: failure)
         } else {
             // special headers
             var headers: [String:String]? = nil
@@ -231,7 +231,7 @@ public class OAuth2Swift: OAuthSwift {
         self.client.request(url, method: method, parameters: parameters, headers: headers, success: success) { (error) in
             switch error.code {
             case OAuthSwiftErrorCode.TokenExpiredError.rawValue:
-                self.renewAccesstokenWithRefreshToken(self.client.credential.oauth_refresh_token, success: { (credential, response, parameters) in
+                self.renewAccesstokenWithRefreshToken(self.client.credential.oauth_refresh_token, headers: headers, success: { (credential, response, parameters) in
                     // We have successfully renewed the access token.
                     
                     // If provided, fire the onRenewal closure

--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -192,7 +192,7 @@ public class OAuth2Swift: OAuthSwift {
 
         if self.content_type == "multipart/form-data" {
             // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
-            self.client.postMultiPartRequest(self.access_token_url!, method: .POST, parameters: parameters, checkTokenExpiration: false, success: successHandler, failure: failure)
+            self.client.postMultiPartRequest(self.access_token_url!, method: .POST, parameters: parameters, headers: [:], checkTokenExpiration: false, success: successHandler, failure: failure)
         } else {
             // special headers
             var headers: [String:String]? = nil

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -207,7 +207,7 @@ public class OAuthSwiftClient: NSObject {
         return data
     }
     
-    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, headers: Dictionary<String, String>, multiparts: Array<OAuthSwiftMultipartData> = [], checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, headers: Dictionary<String, String>? = nil, multiparts: Array<OAuthSwiftMultipartData> = [], checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         
         if let request = makeRequest(url, method: method, parameters: parameters, headers: headers) {
 

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -207,9 +207,9 @@ public class OAuthSwiftClient: NSObject {
         return data
     }
     
-    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, multiparts: Array<OAuthSwiftMultipartData> = [], checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
+    public func postMultiPartRequest(url: String, method: OAuthSwiftHTTPRequest.Method, parameters: Dictionary<String, AnyObject>, headers: Dictionary<String, String>, multiparts: Array<OAuthSwiftMultipartData> = [], checkTokenExpiration: Bool = true, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {
         
-        if let request = makeRequest(url, method: method, parameters: parameters) {
+        if let request = makeRequest(url, method: method, parameters: parameters, headers: headers) {
 
             let boundary = "POST-boundary-\(arc4random())-\(arc4random())"
             let type = "multipart/form-data; boundary=\(boundary)"


### PR DESCRIPTION
### Issue faced
- The services I am working against are expecting certain headers in the multipart request other than "Content-Type"
- Since ```func postMultiPartRequest``` is public it would be convenient to be able to pass headers to the underlying request function.

### Changes made
- Added optional headers parameter and updated all functions affected by it.