### PR TITLE
Support for Device Flow Authentication

### DIFF
--- a/OAuthSwift/OAuth2Swift.swift
+++ b/OAuthSwift/OAuth2Swift.swift
@@ -248,6 +248,20 @@ public class OAuth2Swift: OAuthSwift {
         }
     }
     
+    public func authorizeDeviceToken(deviceCode: String, success: TokenRenewedHandler, failure: OAuthSwiftHTTPRequest.FailureHandler) {
+        var parameters = Dictionary<String, AnyObject>()
+        parameters["client_id"] = self.consumer_key
+        parameters["client_secret"] = self.consumer_secret
+        parameters["code"] = deviceCode
+        parameters["grant_type"] = "http://oauth.net/grant_type/device/1.0"
+        
+        requestOAuthAccessTokenWithParameters(parameters, success: { (credential, response, parameters) in
+            success(credential: credential)
+            }) { (error) in
+                failure(error: error)
+        }
+    }
+    
     @available(*, deprecated=0.5.0, message="Use OAuthSwift.handleOpenURL()")
     public override class func handleOpenURL(url: NSURL) {
         super.handleOpenURL(url)

--- a/OAuthSwift/OAuthSwift.swift
+++ b/OAuthSwift/OAuthSwift.swift
@@ -76,4 +76,5 @@ public enum OAuthSwiftErrorCode: Int {
     case StateNotEqualError = -4
     case ServerError = -5
     case EncodingError = -6
+    case AuthorizationPending = -7
 }

--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -30,6 +30,10 @@ public class OAuthSwiftClient: NSObject {
         self.credential.consumer_key = consumerKey
         self.credential.consumer_secret = consumerSecret
     }
+    
+    public init(credential: OAuthSwiftCredential) {
+        self.credential = credential
+    }
 
     // MARK: client methods
     public func get(urlString: String, parameters: [String: AnyObject] = [:], headers: [String:String]? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) {

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -141,7 +141,7 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                     let responseJSON: AnyObject? = try? NSJSONSerialization.JSONObjectWithData(self.responseData, options: NSJSONReadingOptions.MutableContainers)
                     
                     if let responseJSON = responseJSON {
-                        if let code = responseJSON["error_code"] as? String, description = responseJSON["error_description"] as? String {
+                        if let code = responseJSON["error"] as? String, description = responseJSON["error_description"] as? String {
                             localizedDescription = NSLocalizedString("\(code) \(description)", comment: "")
                             
                             if code == "authorization_pending" {

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -134,14 +134,33 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate {
                 self.responseData.appendData(data!)
 
                 if (response as? NSHTTPURLResponse)?.statusCode >= 400 {
-                    let responseString = NSString(data: self.responseData, encoding: self.dataEncoding)
-                    let localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: responseString! as String)
-                    let userInfo : [NSObject : AnyObject] = [
+                    var errorCode =  OAuthSwiftErrorCode.GeneralError.rawValue
+                    var localizedDescription = String()
+                    let responseString: String
+                    
+                    let responseJSON: AnyObject? = try? NSJSONSerialization.JSONObjectWithData(self.responseData, options: NSJSONReadingOptions.MutableContainers)
+                    
+                    if let responseJSON = responseJSON {
+                        if let code = responseJSON["error_code"] as? String, description = responseJSON["error_description"] as? String {
+                            localizedDescription = NSLocalizedString("\(code) \(description)", comment: "")
+                            
+                            if code == "authorization_pending" {
+                                errorCode = OAuthSwiftErrorCode.AuthorizationPending.rawValue
+                            }
+                        }
+                    } else {
+                        localizedDescription = OAuthSwiftHTTPRequest.descriptionForHTTPStatus(self.response.statusCode, responseString: String(data: self.responseData, encoding: self.dataEncoding)!)
+                    }
+                    
+                    responseString = String(data: self.responseData, encoding: self.dataEncoding)!
+                    
+                    let userInfo = [
                         NSLocalizedDescriptionKey: localizedDescription,
                         "Response-Headers": self.response.allHeaderFields,
                         "Response-Body": responseString ?? NSNull()
                     ]
-                    let error = NSError(domain: NSURLErrorDomain, code: self.response.statusCode, userInfo: userInfo)
+                    
+                    let error = NSError(domain: NSURLErrorDomain, code: errorCode, userInfo: userInfo)
                     self.failureHandler?(error: error)
                     return
                 }


### PR DESCRIPTION
# Summary

Add support for new grant type: [device 1.0](https://tools.ietf.org/html/draft-ietf-oauth-v2-01#section-3.5.3)

# Why

Due to devices with limited capabilities this grant type makes it possible to implement OAuth 2.0 authentication flow easier. 