### PR TITLE
custom modalPresentationStyle in SafariURLHandler

### DIFF
--- a/OAuthSwift/OAuthSwiftURLHandlerType.swift
+++ b/OAuthSwift/OAuthSwiftURLHandlerType.swift
@@ -75,6 +75,8 @@ import SafariServices
         public var dismissCompletion: (() -> Void)?
         public var delay: UInt32? = 1
         
+        public var modalPresentationStyle = UIModalPresentationStyle.FullScreen
+
         // init
         public init(viewController: UIViewController, oauthSwift: OAuthSwift) {
             self.oauthSwift = oauthSwift
@@ -95,6 +97,8 @@ import SafariServices
         @objc public func handle(url: NSURL) {
             let controller = factory(URL: url)
             controller.delegate = self
+
+            controller.modalPresentationStyle = self.modalPresentationStyle
             
             // present controller in main thread
             OAuthSwift.main { [unowned self] in


### PR DESCRIPTION
While using `SafariURLHandler` to implement OAuth flow on an landscaped iPad app, the presented `SFSafariViewController` transients to a new screen from right to left (*i.e.* the default behavior of `UIModalPresentationStyle.FullScreen`). In order to make the view controller behaves like a modal view, it would be great if we can customize behaviors of the view controller created from `factory(url)`.

This PR proposes a naïve way to do this by exposing `modalPresentationStyle` in `SafariURLHandler`, thus we can customize the presented modal style by doing so:

```swift
let handler = SafariURLHandler(viewController: self)
handler.modalPresentationStyle = .FormSheet
oauthswift.authorize_url_handler = handler
```

Or maybe it is better to make a config block/delegate for clients before the controller is presented in `handle(url)`? Thanks in advance!
