### PR TITLE
Invalid oauth_signature

### DIFF
--- a/OAuthSwift/OAuthSwiftCredential.swift
+++ b/OAuthSwift/OAuthSwiftCredential.swift
@@ -202,7 +202,12 @@ public class OAuthSwiftCredential: NSObject, NSCoding {
         let signingKey = "\(encodedConsumerSecret)&\(tokenSecret)"
         
         var parameterComponents = parameters.urlEncodedQueryStringWithEncoding(OAuthSwiftDataEncoding).componentsSeparatedByString("&") as [String]
-        parameterComponents.sortInPlace { $0 < $1 }
+        parameterComponents.sortInPlace {
+            let p0 = $0.componentsSeparatedByString("=")
+            let p1 = $1.componentsSeparatedByString("=")
+            if p0.first == p1.first { return p0.last < p1.last }
+            return p0.first < p1.first
+        }
         
         let parameterString = parameterComponents.joinWithSeparator("&")
         let encodedParameterString = parameterString.urlEncodedStringWithEncoding(OAuthSwiftDataEncoding)

--- a/OAuthSwiftTests/SignTests.swift
+++ b/OAuthSwiftTests/SignTests.swift
@@ -90,6 +90,21 @@ class SignTests: XCTestCase {
 
     }
 
+    func testSignatureWithSamePrefix() {
+
+        testSignature("http://photos.example.net/photos",
+            consumer: "dpf43f3p2l4k3l03",
+            secret: "kd94hf93k423kf44",
+            token: "nnch734d00sl2jdk",
+            token_secret: "pfkkdhi9sl3r4s00",
+            parameters: ["file_1":"vacation.jpg", "file_10":"original"],
+            nonce: "kllo9940pd9333jh",
+            timestamp: "1191242096",
+            method: .GET,
+            expected: "2qG5S5iX/g/6NIKutdcSYACUHsg=")
+
+    }
+
     func testSignature(  url : String
         , consumer : String
         , secret: String


### PR DESCRIPTION
- **OAuthSwift version:** maybe all versions

The OAuth spec says to sort query parameter for generating oauth_signature.

httpy://oauth.net/core/1.0a/#anchor13

> **9.1.1. Normalize Request Parameters**
>
> Parameters are sorted by name, using lexicographical byte value ordering. If two or more parameters share the same name, they are sorted by their value.

So oauth_signature generated by OAuthSwift will be difference other oauth provider.
For example:

- query parameters (dictionary): [ "id_2": 2, "id_10": 0, "id_1": 1 ]
- sorted by OAuthSwift: `id_10=0&id_1=1&id_2=2`
- expected result: `id_1=1&id_10=0&id_2=2`

