### PR TITLE
Fix multipart request with some parameters (swift 2.2)

### DIFF
--- a/OAuthSwift/OAuthSwiftClient.swift
+++ b/OAuthSwift/OAuthSwiftClient.swift
@@ -113,7 +113,7 @@ public class OAuthSwiftClient: NSObject {
         let paramImage: [String: AnyObject] = ["media": image]
         let boundary = "AS-boundary-\(arc4random())-\(arc4random())"
         let type = "multipart/form-data; boundary=\(boundary)"
-        let body = self.multiPartBodyFromParams(paramImage, boundary: boundary)
+        let body = self.multiPartBodyFromParams(paramImage + parameters, boundary: boundary)
         let headers = [kHTTPHeaderContentType: type]
 
         if let request = makeRequest(url, method: method, parameters: parameters, headers: headers, body: body) { // TODO check if headers do not override others...

--- a/OAuthSwift/OAuthSwiftHTTPRequest.swift
+++ b/OAuthSwift/OAuthSwiftHTTPRequest.swift
@@ -282,6 +282,9 @@ public class OAuthSwiftHTTPRequest: NSObject, NSURLSessionDelegate, OAuthSwiftRe
                         request.setValue("application/json; charset=\(charset)", forHTTPHeaderField: kHTTPHeaderContentType)
                         request.HTTPBody = jsonData
                     }
+                    else if let contentType = finalHeaders[kHTTPHeaderContentType] where contentType.rangeOfString("multipart/form-data") != nil {
+                        // snip
+                    }
                     else {
                         request.setValue("application/x-www-form-urlencoded; charset=\(charset)", forHTTPHeaderField: kHTTPHeaderContentType)
                         let queryString = finalParameters.urlEncodedQueryStringWithEncoding(dataEncoding)

--- a/OAuthSwiftTests/OAuthSwiftClientTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftClientTests.swift
@@ -128,6 +128,17 @@ class OAuthSwiftClientTests: XCTestCase {
             XCTFail("\(e)")
         }
     }
+
+    func testMultiPartBodyFromParams() {
+        let binary = "binary".dataUsingEncoding(NSUTF8StringEncoding)!
+        let parameters: [String:AnyObject] = [ "media": binary, "a": "b" ]
+        let data = client.multiPartBodyFromParams(parameters, boundary: "boundary")
+        let result = String(data: data, encoding: NSUTF8StringEncoding)!
+
+        let expectedString = "--boundary\r\nContent-Disposition: form-data; name=\"a\";\r\n\r\nb\r\n--boundary\r\nContent-Disposition: form-data; name=\"media\"; filename=\"file\"\r\nContent-Type: image/jpeg\r\n\r\nbinary\r\n--boundary--\r\n"
+        XCTAssertEqual(result, expectedString)
+    }
+
 }
 
 extension XCTestCase {

--- a/OAuthSwiftTests/OAuthSwiftClientTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftClientTests.swift
@@ -139,6 +139,30 @@ class OAuthSwiftClientTests: XCTestCase {
         XCTAssertEqual(result, expectedString)
     }
 
+    func testMakeMultipartRequest() {
+        let binary = "binary".dataUsingEncoding(NSUTF8StringEncoding)!
+        let multiparts = [ OAuthSwiftMultipartData(name: "media", data: binary, fileName: "file", mimeType: "image/jpeg") ]
+        let request = client.makeMultiPartRequest(url, method: .POST, multiparts: multiparts)!
+
+        XCTAssertEqualURL(request.config.URL!, NSURL(string: url)!)
+
+        let bodyString = String(data: request.config.urlRequest.HTTPBody!, encoding: OAuthSwiftDataEncoding)
+        XCTAssertNotNil(bodyString?.rangeOfString("image/jpeg\r\n\r\nbinary\r\n"))
+    }
+
+    func testMakeMultipartRequestWithParameter() {
+        let binary = "binary".dataUsingEncoding(NSUTF8StringEncoding)!
+        let multiparts = [ OAuthSwiftMultipartData(name: "media", data: binary, fileName: "file", mimeType: "image/jpeg") ]
+        let parameters: [String:AnyObject] = [ "a": "b" ]
+        let request = client.makeMultiPartRequest(url, method: .POST, parameters: parameters, multiparts: multiparts)!
+
+        XCTAssertEqualURL(request.config.URL!, NSURL(string: url)!)
+
+        let bodyString = String(data: request.config.urlRequest.HTTPBody!, encoding: OAuthSwiftDataEncoding)
+        XCTAssertNotNil(bodyString?.rangeOfString("image/jpeg\r\n\r\nbinary\r\n"))
+        XCTAssertNotNil(bodyString?.rangeOfString("form-data; name=\"a\";\r\n\r\nb"))
+    }
+
 }
 
 extension XCTestCase {


### PR DESCRIPTION
A request body would be overridden by query parameters with multipart request.

For example:
- SUCCESS: client.postImage(url, parameters: [:], image: imageData, ....
- FAILURE: client.postImage(url, parameters: parameters, image: imageData, ....

just a fix of this issue is in 21e870acca7e169c871e1d15b0df4fd13a7f2086

I will create pull request to master too later :D