### PR TITLE
Remove 'access_token' parameter when renewing OAuth2 token

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -261,9 +261,13 @@ open class OAuth2Swift: OAuthSwift {
                     if let renewalCallBack = onTokenRenewal {
                         renewalCallBack(credential)
                     }
-                    
+                  
+                    // Unset access_token parameter
+                    var authParameters = parameters
+                    authParameters.removeValue(forKey: "access_token")
+                  
                     // Reauthorize the request again, this time with a brand new access token ready to be used.
-                   let _ = self.startAuthorizedRequest(url, method: method, parameters: parameters, headers: headers, onTokenRenewal: onTokenRenewal, success: success, failure: failure)
+                   let _ = self.startAuthorizedRequest(url, method: method, parameters: authParameters, headers: headers, onTokenRenewal: onTokenRenewal, success: success, failure: failure)
                     }, failure: failure)
             default:
                 failure(error)

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -254,7 +254,7 @@ open class OAuth2Swift: OAuthSwift {
             switch error {
 
             case OAuthSwiftError.tokenExpired:
-                let _ = self.renewAccessToken(withRefreshToken: self.client.credential.oauthRefreshToken, headers: headers, success: { (credential, response, parameters) in
+                let _ = self.renewAccessToken(withRefreshToken: self.client.credential.oauthRefreshToken, headers: headers, success: { (credential, response, _) in // Ommit response parameters so they don't override the original ones
                     // We have successfully renewed the access token.
                     
                     // If provided, fire the onRenewal closure
@@ -262,12 +262,8 @@ open class OAuth2Swift: OAuthSwift {
                         renewalCallBack(credential)
                     }
                   
-                    // Unset access_token parameter
-                    var authParameters = parameters
-                    authParameters.removeValue(forKey: "access_token")
-                  
                     // Reauthorize the request again, this time with a brand new access token ready to be used.
-                   let _ = self.startAuthorizedRequest(url, method: method, parameters: authParameters, headers: headers, onTokenRenewal: onTokenRenewal, success: success, failure: failure)
+                   let _ = self.startAuthorizedRequest(url, method: method, parameters: parameters, headers: headers, onTokenRenewal: onTokenRenewal, success: success, failure: failure)
                     }, failure: failure)
             default:
                 failure(error)


### PR DESCRIPTION
Some services (tested with Spotify) will fail the request for a new token when the access token is specified both as a parameter and a header. 

This commit removes the access_token field from the parameters when automatically renewing a token.