### PR TITLE
Fix: encode redirect_uri

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -120,7 +120,7 @@ open class OAuth2Swift: OAuthSwift {
 
         
         var queryString = "client_id=\(self.consumerKey)"
-        queryString += "&redirect_uri=\(callbackURL.absoluteString)"
+        queryString += "&redirect_uri=\(callbackURL.absoluteString.urlEncodedString)"
         queryString += "&response_type=\(self.responseType)"
         if !scope.isEmpty {
             queryString += "&scope=\(scope)"


### PR DESCRIPTION
The redirect_uri was not encoded. This causes issues when the redirect_uri contains query parameters. Encoding the uri makes sure the entire string is used, and not mixed up with and other parameters on the url.