### PR TITLE
Make requestOAuthAccessToken open

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -167,8 +167,8 @@ open class OAuth2Swift: OAuthSwift {
     }
     
     @discardableResult
-    open func renewAccessToken(withRefreshToken refreshToken: String, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
-      var parameters = OAuthSwift.Parameters()
+    open func renewAccessToken(withRefreshToken refreshToken: String, parameters: OAuthSwift.Parameters? = nil, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
+      var parameters = parameters ?? OAuthSwift.Parameters()
         parameters["client_id"] = self.consumerKey
         parameters["client_secret"] = self.consumerSecret
         parameters["refresh_token"] = refreshToken
@@ -177,7 +177,7 @@ open class OAuth2Swift: OAuthSwift {
         return requestOAuthAccessToken(withParameters: parameters, headers: headers, success: success, failure: failure)
     }
     
-    open func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
+    fileprivate func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
         let successHandler: OAuthSwiftHTTPRequest.SuccessHandler = { [unowned self]
             response in
             let responseJSON: Any? = try? response.jsonObject(options: .mutableContainers)

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -177,7 +177,7 @@ open class OAuth2Swift: OAuthSwift {
         return requestOAuthAccessToken(withParameters: parameters, headers: headers, success: success, failure: failure)
     }
     
-    fileprivate func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
+    open func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
         let successHandler: OAuthSwiftHTTPRequest.SuccessHandler = { [unowned self]
             response in
             let responseJSON: Any? = try? response.jsonObject(options: .mutableContainers)


### PR DESCRIPTION
We have an interesting use case with Microsoft's OAuth (Azure AD, Graph API, Outlook API, etc)

Oauth tokens are scoped to a single resource. However, Microsoft allows refresh tokens to be used to request additional tokens for other resources.  The easiest way to do this is to call requestOAuthAccessToken for each additional resource we intend to use with the additional resource parameters we need to specify.

Opening requestOAuthAccessToken makes it much simpler for us to request additional access tokens.