### PR TITLE
Fix a crash when encoding credentials in a test target

### DIFF
--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0738BC6B1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0738BC6A1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift */; };
 		6053EF6F1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
 		6053EF701E93832400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
 		6053EF711E93832500EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
@@ -197,6 +198,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0738BC6A1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftCredentialTests.swift; sourceTree = "<group>"; };
 		0ED45F76F07F16FB6FF639B7 /* Pods_OAuthSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OAuthSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+OAuthSwift.swift"; sourceTree = "<group>"; };
 		674EB2AA3430160EBBAC72A1 /* Pods-OAuthSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OAuthSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -471,6 +473,7 @@
 				C4E46C501D462ED300BFCEF4 /* OAuthSwiftErrorTest.swift */,
 				C4D50E0A1BFB74240053B624 /* OAuthSwiftRequestTests.swift */,
 				C4698E331BFDE25500FADE29 /* OAuthSwiftClientTests.swift */,
+				0738BC6A1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift */,
 				C4D50DF91BFB693F0053B624 /* OAuth1SwiftTests.swift */,
 				C4D50E0C1BFB79D00053B624 /* OAuth2SwiftTests.swift */,
 				C4FAE4351C061660000CE669 /* SignTests.swift */,
@@ -1043,6 +1046,7 @@
 				C40C96D91DA639B700197628 /* UtilsTests.swift in Sources */,
 				C4FAE4361C061660000CE669 /* SignTests.swift in Sources */,
 				C44244DC1C06316E00880DAB /* Services.swift in Sources */,
+				0738BC6B1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift in Sources */,
 				C4D50DFA1BFB693F0053B624 /* OAuth1SwiftTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OAuthSwiftTests/OAuthSwiftCredentialTests.swift
+++ b/OAuthSwiftTests/OAuthSwiftCredentialTests.swift
@@ -1,0 +1,27 @@
+//
+//  OAuthSwiftCredentialTests.swift
+//  OAuthSwift
+//
+//  Created by you on 03.05.17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import OAuthSwift
+import XCTest
+
+/**
+ Simply calls the function `f` and returns its result. It's introduced
+ for semantic meaning to highlight what code should not crash, because
+ swift's `XCTest` doesn't have the `XCTAssertNoThrow` assert.
+ */
+func nop_ShouldNotCrash <A> (_ f: @autoclosure () -> (A)) -> A {
+    return f()
+}
+
+class OAuthSwiftCredentialTests: XCTestCase {
+    func testEncodeShouldNotCrashWhenMainBundleIdentifierIsNil() {
+        let credential = OAuthSwiftCredential(consumerKey: "foo", consumerSecret: "bar")
+        let data = nop_ShouldNotCrash(NSKeyedArchiver.archivedData(withRootObject: credential))
+        XCTAssertGreaterThan(data.count, 0)
+    }
+}

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -94,7 +94,10 @@ open class OAuthSwiftCredential: NSObject, NSCoding {
 
     // MARK: NSCoding protocol
     fileprivate struct CodingKeys {
-        static let base = Bundle.main.bundleIdentifier! + "."
+        static let bundleId = Bundle.main.bundleIdentifier
+            ?? Bundle(for: OAuthSwiftCredential.self).bundleIdentifier
+            ?? ""
+        static let base = bundleId + "."
         static let consumerKey = base + "comsumer_key"
         static let consumerSecret = base + "consumer_secret"
         static let oauthToken = base + "oauth_token"


### PR DESCRIPTION
When `NSCoding` an `OAuthSwiftCredential` instance, the test would crash
on `CodingKeys` initialization because the `bundleIdentifier` of the
`Bundle.main` in the tests is `nil` (the main bundle is not app's
bundle). This patch fixes that by trying to get one of the bundle
identifiers: the `main` one, the bundle for the `OAuthSwiftCredential`
class, or an empty string otherwise; a test is added to verify the fix.