### PR TITLE
Add callback URL to authorization URL, not request token URL

### DIFF
--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -90,7 +90,8 @@ open class OAuth1Swift: OAuthSwift {
             }
             // 2. Authorize
             let urlString = self.authorizeUrl + (self.authorizeUrl.contains("?") ? "&" : "?")
-            if let token = credential.oauthToken.urlQueryEncoded, let queryURL = URL(string: urlString + "oauth_token=\(token)") {
+            if let token = credential.oauthToken.urlQueryEncoded,
+				let queryURL = URL(string: urlString + "oauth_token=\(token)&oauth_callback=\(callbackURL.absoluteString)") {
                 self.authorizeURLHandler.handle(queryURL)
             } else {
                 failure?(OAuthSwiftError.encodingError(urlString: urlString))


### PR DESCRIPTION
It looks like the callback URL is currently being added as a parameter on the request token URL, but it should really be part of the authorization URL. This change adds the callback to the authorization URL.