### PR TITLE
Adding convenience initializer and documentation for OAuth 1.0a requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ let handle = oauthswift.authorize(
     }             
 )
 ```
+
+### Request example with OAuth1.0a
+```swift
+// create an instance and retain it
+oauthswift = OAuth1Swift(
+consumerKey:    "********",
+consumerSecret: "********")
+
+oauthswift.client.get("http://api.example.com/foo/bar", success: { data in
+//....
+}, failure: { error in
+//...
+})
+```
+
+
 ### Authorize with OAuth2.0
 ```swift
 oauthswift = OAuth2Swift(

--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -30,6 +30,10 @@ open class OAuth1Swift: OAuthSwift {
         super.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
         self.client.credential.version = .oauth1
     }
+    
+    public convenience override init(consumerKey: String, consumerSecret: String) {
+        self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, requestTokenUrl: "", authorizeUrl: "", accessTokenUrl: "")
+    }
 
     public convenience init?(parameters: ConfigParameters) {
         guard let consumerKey = parameters["consumerKey"], let consumerSecret = parameters["consumerSecret"],


### PR DESCRIPTION
The readme is unclear about how to make OAuth 1.0a requests. I added a convenience initializer that will set all the unnecessary `OAuth1Swift()` init params to the required empty strings to get it to work.