### PR TITLE
Refactor o auth swift credential

### DIFF
--- a/Demo/Common/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Demo/Common/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -91,6 +91,11 @@
       "idiom" : "ipad",
       "filename" : "oauthswift-icon-153.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -8,6 +8,50 @@
 
 /* Begin PBXBuildFile section */
 		0738BC6B1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0738BC6A1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift */; };
+		5F4C09701EFACCB60013CFF0 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C096F1EFACCB60013CFF0 /* OAuthSwiftCredential.swift */; };
+		5F4C09721EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09711EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift */; };
+		5F4C09781EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09771EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift */; };
+		5F4C097A1EFC19580013CFF0 /* OAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09791EFC19580013CFF0 /* OAuthSwiftVersion.swift */; };
+		5F4C097D1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097C1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift */; };
+		5F4C097F1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097E1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift */; };
+		5F4C09801EFC24780013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09711EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift */; };
+		5F4C09811EFC24790013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09711EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift */; };
+		5F4C09821EFC247A0013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09711EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift */; };
+		5F4C09831EFC247E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097C1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift */; };
+		5F4C09841EFC247E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097C1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift */; };
+		5F4C09851EFC247F0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097C1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift */; };
+		5F4C09861EFC24820013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097E1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift */; };
+		5F4C09871EFC24820013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097E1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift */; };
+		5F4C09881EFC24820013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C097E1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift */; };
+		5F4C09891EFC24860013CFF0 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C096F1EFACCB60013CFF0 /* OAuthSwiftCredential.swift */; };
+		5F4C098A1EFC24870013CFF0 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C096F1EFACCB60013CFF0 /* OAuthSwiftCredential.swift */; };
+		5F4C098B1EFC24870013CFF0 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C096F1EFACCB60013CFF0 /* OAuthSwiftCredential.swift */; };
+		5F4C098C1EFC248A0013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09771EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift */; };
+		5F4C098D1EFC248B0013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09771EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift */; };
+		5F4C098E1EFC248C0013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09771EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift */; };
+		5F4C098F1EFC248F0013CFF0 /* OAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09791EFC19580013CFF0 /* OAuthSwiftVersion.swift */; };
+		5F4C09901EFC24900013CFF0 /* OAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09791EFC19580013CFF0 /* OAuthSwiftVersion.swift */; };
+		5F4C09911EFC24900013CFF0 /* OAuthSwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09791EFC19580013CFF0 /* OAuthSwiftVersion.swift */; };
+		5F4C09941EFC331F0013CFF0 /* OAuth1SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09931EFC331F0013CFF0 /* OAuth1SwiftCredential.swift */; };
+		5F4C09961EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09951EFC33460013CFF0 /* OAuth2SwiftCredential.swift */; };
+		5F4C09971EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09951EFC33460013CFF0 /* OAuth2SwiftCredential.swift */; };
+		5F4C09981EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09951EFC33460013CFF0 /* OAuth2SwiftCredential.swift */; };
+		5F4C09991EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09951EFC33460013CFF0 /* OAuth2SwiftCredential.swift */; };
+		5F4C099A1EFC33540013CFF0 /* OAuth1SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09931EFC331F0013CFF0 /* OAuth1SwiftCredential.swift */; };
+		5F4C099B1EFC33550013CFF0 /* OAuth1SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09931EFC331F0013CFF0 /* OAuth1SwiftCredential.swift */; };
+		5F4C099C1EFC33550013CFF0 /* OAuth1SwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09931EFC331F0013CFF0 /* OAuth1SwiftCredential.swift */; };
+		5F4C099E1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C099D1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift */; };
+		5F4C099F1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C099D1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift */; };
+		5F4C09A01EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C099D1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift */; };
+		5F4C09A11EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C099D1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift */; };
+		5F4C09A31EFC33870013CFF0 /* OAuth1Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A21EFC33870013CFF0 /* OAuth1Version.swift */; };
+		5F4C09A41EFC33870013CFF0 /* OAuth1Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A21EFC33870013CFF0 /* OAuth1Version.swift */; };
+		5F4C09A51EFC33870013CFF0 /* OAuth1Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A21EFC33870013CFF0 /* OAuth1Version.swift */; };
+		5F4C09A61EFC33870013CFF0 /* OAuth1Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A21EFC33870013CFF0 /* OAuth1Version.swift */; };
+		5F4C09A81EFC339F0013CFF0 /* OAuth2Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A71EFC339F0013CFF0 /* OAuth2Version.swift */; };
+		5F4C09A91EFC339F0013CFF0 /* OAuth2Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A71EFC339F0013CFF0 /* OAuth2Version.swift */; };
+		5F4C09AA1EFC339F0013CFF0 /* OAuth2Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A71EFC339F0013CFF0 /* OAuth2Version.swift */; };
+		5F4C09AB1EFC339F0013CFF0 /* OAuth2Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4C09A71EFC339F0013CFF0 /* OAuth2Version.swift */; };
 		6053EF6F1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
 		6053EF701E93832400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
 		6053EF711E93832500EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
@@ -17,7 +61,6 @@
 		C40890C81C11B38000E3146A /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		C40890C91C11B38000E3146A /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
 		C40890CA1C11B38000E3146A /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
-		C40890CB1C11B38000E3146A /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */; };
 		C40890CC1C11B38000E3146A /* OAuthSwiftHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */; };
 		C40890CD1C11B38000E3146A /* OAuthSwiftURLHandlerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */; };
 		C40890CE1C11B38000E3146A /* OAuthWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */; };
@@ -60,7 +103,6 @@
 		C48B28211AFA599400C7DEF6 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		C48B28221AFA599700C7DEF6 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
 		C48B28231AFA599A00C7DEF6 /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
-		C48B28241AFA599A00C7DEF6 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */; };
 		C48B28251AFA599A00C7DEF6 /* OAuthSwiftHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */; };
 		C48B28261AFA599A00C7DEF6 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599AE1A78FFAF004A96C1 /* Utils.swift */; };
 		C48B28271AFA599A00C7DEF6 /* SHA1.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47599AC1A78FF23004A96C1 /* SHA1.swift */; };
@@ -80,7 +122,6 @@
 		C4B6EE261BF74CF400443596 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		C4B6EE271BF74CF400443596 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
 		C4B6EE281BF74CF400443596 /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
-		C4B6EE291BF74CF400443596 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */; };
 		C4B6EE2A1BF74CF400443596 /* OAuthSwiftHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */; };
 		C4B6EE2B1BF74CF400443596 /* OAuthSwiftURLHandlerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */; };
 		C4B6EE2C1BF74CF400443596 /* OAuthWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496246E1B00D6C30010BD09 /* OAuthWebViewController.swift */; };
@@ -142,7 +183,6 @@
 		F4E9A4DC1A67944C00B4F3C8 /* OAuth1Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502681A6790EC00038A29 /* OAuth1Swift.swift */; };
 		F4E9A4DD1A67944C00B4F3C8 /* OAuth2Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43502691A6790EC00038A29 /* OAuth2Swift.swift */; };
 		F4E9A4DE1A67944C00B4F3C8 /* OAuthSwiftClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */; };
-		F4E9A4DF1A67944C00B4F3C8 /* OAuthSwiftCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */; };
 		F4E9A4E01A67944C00B4F3C8 /* OAuthSwiftHTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */; };
 		F4E9A8011B08635E0003988B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F451E3E4195B8D030051434C /* Images.xcassets */; };
 /* End PBXBuildFile section */
@@ -200,6 +240,17 @@
 /* Begin PBXFileReference section */
 		0738BC6A1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthSwiftCredentialTests.swift; sourceTree = "<group>"; };
 		0ED45F76F07F16FB6FF639B7 /* Pods_OAuthSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OAuthSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F4C096F1EFACCB60013CFF0 /* OAuthSwiftCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSwiftCredential.swift; sourceTree = "<group>"; };
+		5F4C09711EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseOAuthSwiftCredential.swift; sourceTree = "<group>"; };
+		5F4C09771EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSwiftSignatureMethod.swift; sourceTree = "<group>"; };
+		5F4C09791EFC19580013CFF0 /* OAuthSwiftVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthSwiftVersion.swift; sourceTree = "<group>"; };
+		5F4C097C1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseOAuthSwiftSignatureMethod.swift; sourceTree = "<group>"; };
+		5F4C097E1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseOAuthSwiftVersion.swift; sourceTree = "<group>"; };
+		5F4C09931EFC331F0013CFF0 /* OAuth1SwiftCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth1SwiftCredential.swift; sourceTree = "<group>"; };
+		5F4C09951EFC33460013CFF0 /* OAuth2SwiftCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2SwiftCredential.swift; sourceTree = "<group>"; };
+		5F4C099D1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMAC_SHA1SignatureMethod.swift; sourceTree = "<group>"; };
+		5F4C09A21EFC33870013CFF0 /* OAuth1Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth1Version.swift; sourceTree = "<group>"; };
+		5F4C09A71EFC339F0013CFF0 /* OAuth2Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Version.swift; sourceTree = "<group>"; };
 		6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+OAuthSwift.swift"; sourceTree = "<group>"; };
 		674EB2AA3430160EBBAC72A1 /* Pods-OAuthSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OAuthSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OAuthSwiftTests/Pods-OAuthSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C40890C01C11B37000E3146A /* OAuthSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -250,7 +301,6 @@
 		F43502681A6790EC00038A29 /* OAuth1Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuth1Swift.swift; sourceTree = "<group>"; };
 		F43502691A6790EC00038A29 /* OAuth2Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuth2Swift.swift; sourceTree = "<group>"; };
 		F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuthSwiftClient.swift; sourceTree = "<group>"; };
-		F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuthSwiftCredential.swift; sourceTree = "<group>"; };
 		F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = OAuthSwiftHTTPRequest.swift; sourceTree = "<group>"; };
 		F435027A1A6791B200038A29 /* OAuthSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OAuthSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F435027D1A6791B200038A29 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = Xcode/iOS/Info.plist; sourceTree = "<group>"; };
@@ -338,6 +388,48 @@
 				0ED45F76F07F16FB6FF639B7 /* Pods_OAuthSwiftTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5F4C09731EFB149C0013CFF0 /* Credential */ = {
+			isa = PBXGroup;
+			children = (
+				5F4C09921EFC33000013CFF0 /* Concrete Credential Classes */,
+				5F4C097B1EFC1A3D0013CFF0 /* Credential Base Classes */,
+				5F4C09761EFC18E00013CFF0 /* Credential Protocols */,
+			);
+			path = Credential;
+			sourceTree = "<group>";
+		};
+		5F4C09761EFC18E00013CFF0 /* Credential Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				5F4C096F1EFACCB60013CFF0 /* OAuthSwiftCredential.swift */,
+				5F4C09771EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift */,
+				5F4C09791EFC19580013CFF0 /* OAuthSwiftVersion.swift */,
+			);
+			path = "Credential Protocols";
+			sourceTree = "<group>";
+		};
+		5F4C097B1EFC1A3D0013CFF0 /* Credential Base Classes */ = {
+			isa = PBXGroup;
+			children = (
+				5F4C09711EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift */,
+				5F4C097C1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift */,
+				5F4C097E1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift */,
+			);
+			path = "Credential Base Classes";
+			sourceTree = "<group>";
+		};
+		5F4C09921EFC33000013CFF0 /* Concrete Credential Classes */ = {
+			isa = PBXGroup;
+			children = (
+				5F4C09931EFC331F0013CFF0 /* OAuth1SwiftCredential.swift */,
+				5F4C09951EFC33460013CFF0 /* OAuth2SwiftCredential.swift */,
+				5F4C099D1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift */,
+				5F4C09A21EFC33870013CFF0 /* OAuth1Version.swift */,
+				5F4C09A71EFC339F0013CFF0 /* OAuth2Version.swift */,
+			);
+			path = "Concrete Credential Classes";
 			sourceTree = "<group>";
 		};
 		C40890C11C11B37000E3146A /* WatchOS */ = {
@@ -505,7 +597,7 @@
 				F43502681A6790EC00038A29 /* OAuth1Swift.swift */,
 				F43502691A6790EC00038A29 /* OAuth2Swift.swift */,
 				F435026A1A6790EC00038A29 /* OAuthSwiftClient.swift */,
-				F435026B1A6790EC00038A29 /* OAuthSwiftCredential.swift */,
+				5F4C09731EFB149C0013CFF0 /* Credential */,
 				F435026C1A6790EC00038A29 /* OAuthSwiftHTTPRequest.swift */,
 				C42349981DCCE5F600BD980F /* OAuthSwiftResponse.swift */,
 				C49624711B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift */,
@@ -954,22 +1046,32 @@
 				C40890C91C11B38000E3146A /* OAuth2Swift.swift in Sources */,
 				C423499C1DCCE5F600BD980F /* OAuthSwiftResponse.swift in Sources */,
 				C40890CC1C11B38000E3146A /* OAuthSwiftHTTPRequest.swift in Sources */,
+				5F4C099C1EFC33550013CFF0 /* OAuth1SwiftCredential.swift in Sources */,
+				5F4C09991EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */,
+				5F4C09AB1EFC339F0013CFF0 /* OAuth2Version.swift in Sources */,
 				C40890D31C11B38700E3146A /* URL+OAuthSwift.swift in Sources */,
 				C40890C81C11B38000E3146A /* OAuth1Swift.swift in Sources */,
 				6053EF721E93832600EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */,
-				C40890CB1C11B38000E3146A /* OAuthSwiftCredential.swift in Sources */,
 				C40890D21C11B38700E3146A /* Dictionary+OAuthSwift.swift in Sources */,
+				5F4C09A11EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */,
 				C40890CD1C11B38000E3146A /* OAuthSwiftURLHandlerType.swift in Sources */,
 				C40890D01C11B38000E3146A /* SHA1.swift in Sources */,
 				C40890D41C11B38700E3146A /* String+OAuthSwift.swift in Sources */,
+				5F4C09881EFC24820013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */,
+				5F4C098B1EFC24870013CFF0 /* OAuthSwiftCredential.swift in Sources */,
 				C40890DB1C11D48300E3146A /* OAuthSwift.swift in Sources */,
 				C4328F671DA1958D00847FA3 /* OAuthSwiftError.swift in Sources */,
 				C40890D11C11B38000E3146A /* HMAC.swift in Sources */,
 				C40890CA1C11B38000E3146A /* OAuthSwiftClient.swift in Sources */,
 				C40890CE1C11B38000E3146A /* OAuthWebViewController.swift in Sources */,
+				5F4C09851EFC247F0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */,
 				C40890D61C11B38700E3146A /* Int+OAuthSwift.swift in Sources */,
+				5F4C09A61EFC33870013CFF0 /* OAuth1Version.swift in Sources */,
 				C4E46C4F1D462D4B00BFCEF4 /* NSError+OAuthSwift.swift in Sources */,
+				5F4C09821EFC247A0013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */,
+				5F4C098E1EFC248C0013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */,
 				C40890D51C11B38700E3146A /* Data+OAuthSwift.swift in Sources */,
+				5F4C09911EFC24900013CFF0 /* OAuthSwiftVersion.swift in Sources */,
 				C40890CF1C11B38000E3146A /* Utils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -983,22 +1085,32 @@
 				C48B28221AFA599700C7DEF6 /* OAuth2Swift.swift in Sources */,
 				C423499A1DCCE5F600BD980F /* OAuthSwiftResponse.swift in Sources */,
 				C48B28251AFA599A00C7DEF6 /* OAuthSwiftHTTPRequest.swift in Sources */,
+				5F4C099A1EFC33540013CFF0 /* OAuth1SwiftCredential.swift in Sources */,
+				5F4C09971EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */,
+				5F4C09A91EFC339F0013CFF0 /* OAuth2Version.swift in Sources */,
 				C48B28211AFA599400C7DEF6 /* OAuth1Swift.swift in Sources */,
 				C48B282B1AFA599A00C7DEF6 /* String+OAuthSwift.swift in Sources */,
 				6053EF701E93832400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */,
 				C49624731B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift in Sources */,
-				C48B28241AFA599A00C7DEF6 /* OAuthSwiftCredential.swift in Sources */,
+				5F4C099F1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */,
 				C48B282A1AFA599A00C7DEF6 /* URL+OAuthSwift.swift in Sources */,
 				C48B282C1AFA599A00C7DEF6 /* Data+OAuthSwift.swift in Sources */,
 				C48B28271AFA599A00C7DEF6 /* SHA1.swift in Sources */,
+				5F4C09861EFC24820013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */,
+				5F4C09891EFC24860013CFF0 /* OAuthSwiftCredential.swift in Sources */,
 				C40890D91C11D48300E3146A /* OAuthSwift.swift in Sources */,
 				C4328F651DA1958D00847FA3 /* OAuthSwiftError.swift in Sources */,
 				C48B28231AFA599A00C7DEF6 /* OAuthSwiftClient.swift in Sources */,
 				C48B28281AFA599A00C7DEF6 /* HMAC.swift in Sources */,
 				C48B282D1AFA599C00C7DEF6 /* Int+OAuthSwift.swift in Sources */,
+				5F4C09831EFC247E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */,
 				C48B28261AFA599A00C7DEF6 /* Utils.swift in Sources */,
+				5F4C09A41EFC33870013CFF0 /* OAuth1Version.swift in Sources */,
 				C4E46C4D1D462D4B00BFCEF4 /* NSError+OAuthSwift.swift in Sources */,
+				5F4C09801EFC24780013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */,
+				5F4C098C1EFC248A0013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */,
 				C48B28291AFA599A00C7DEF6 /* Dictionary+OAuthSwift.swift in Sources */,
+				5F4C098F1EFC248F0013CFF0 /* OAuthSwiftVersion.swift in Sources */,
 				C49624701B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1022,13 +1134,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				D20BBB771C2459CF00F2B012 /* OAuthSwiftMultipartData.swift in Sources */,
+				5F4C09A01EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */,
+				5F4C09AA1EFC339F0013CFF0 /* OAuth2Version.swift in Sources */,
 				C4B6EE261BF74CF400443596 /* OAuth1Swift.swift in Sources */,
 				C4B6EE271BF74CF400443596 /* OAuth2Swift.swift in Sources */,
 				C4B6EE281BF74CF400443596 /* OAuthSwiftClient.swift in Sources */,
-				C4B6EE291BF74CF400443596 /* OAuthSwiftCredential.swift in Sources */,
+				5F4C098A1EFC24870013CFF0 /* OAuthSwiftCredential.swift in Sources */,
+				5F4C09A51EFC33870013CFF0 /* OAuth1Version.swift in Sources */,
 				C4B6EE2A1BF74CF400443596 /* OAuthSwiftHTTPRequest.swift in Sources */,
+				5F4C098D1EFC248B0013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */,
 				C4328F661DA1958D00847FA3 /* OAuthSwiftError.swift in Sources */,
+				5F4C099B1EFC33550013CFF0 /* OAuth1SwiftCredential.swift in Sources */,
 				C4B6EE2B1BF74CF400443596 /* OAuthSwiftURLHandlerType.swift in Sources */,
+				5F4C09841EFC247E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */,
 				C4E46C4E1D462D4B00BFCEF4 /* NSError+OAuthSwift.swift in Sources */,
 				C4B6EE2C1BF74CF400443596 /* OAuthWebViewController.swift in Sources */,
 				C4B6EE2D1BF74CF400443596 /* Utils.swift in Sources */,
@@ -1041,7 +1159,11 @@
 				C4B6EE321BF74CF400443596 /* String+OAuthSwift.swift in Sources */,
 				C4B6EE331BF74CF400443596 /* Data+OAuthSwift.swift in Sources */,
 				C42D41BD1C1AD11600DEDF53 /* UIApplication+OAuthSwift.swift in Sources */,
+				5F4C09981EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */,
 				C4B6EE341BF74CF400443596 /* Int+OAuthSwift.swift in Sources */,
+				5F4C09811EFC24790013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */,
+				5F4C09901EFC24900013CFF0 /* OAuthSwiftVersion.swift in Sources */,
+				5F4C09871EFC24820013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */,
 				C4328F611DA158AD00847FA3 /* Collection+OAuthSwift.swift in Sources */,
 				6053EF711E93832500EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */,
 			);
@@ -1071,27 +1193,37 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4E9A4DC1A67944C00B4F3C8 /* OAuth1Swift.swift in Sources */,
+				5F4C09A81EFC339F0013CFF0 /* OAuth2Version.swift in Sources */,
 				F4E9A4DD1A67944C00B4F3C8 /* OAuth2Swift.swift in Sources */,
+				5F4C09701EFACCB60013CFF0 /* OAuthSwiftCredential.swift in Sources */,
 				F47599B31A7901DF004A96C1 /* HMAC.swift in Sources */,
 				F4805E231A6BB5DD00F7677E /* String+OAuthSwift.swift in Sources */,
 				C49624721B00F54A0010BD09 /* OAuthSwiftURLHandlerType.swift in Sources */,
 				F4E9A4DE1A67944C00B4F3C8 /* OAuthSwiftClient.swift in Sources */,
+				5F4C09721EFAF2800013CFF0 /* BaseOAuthSwiftCredential.swift in Sources */,
 				C4328F641DA1958D00847FA3 /* OAuthSwiftError.swift in Sources */,
-				F4E9A4DF1A67944C00B4F3C8 /* OAuthSwiftCredential.swift in Sources */,
 				C4E46C4C1D462D4B00BFCEF4 /* NSError+OAuthSwift.swift in Sources */,
 				F47599AF1A78FFAF004A96C1 /* Utils.swift in Sources */,
 				D20BBB751C2454A900F2B012 /* OAuthSwiftMultipartData.swift in Sources */,
+				5F4C09A31EFC33870013CFF0 /* OAuth1Version.swift in Sources */,
 				C4F6FE7D1DCE3AC300C0B62A /* Objc.swift in Sources */,
 				F47599AD1A78FF23004A96C1 /* SHA1.swift in Sources */,
+				5F4C09941EFC331F0013CFF0 /* OAuth1SwiftCredential.swift in Sources */,
 				C40890D81C11D48300E3146A /* OAuthSwift.swift in Sources */,
 				F4805E221A6BB5DD00F7677E /* URL+OAuthSwift.swift in Sources */,
+				5F4C09961EFC33460013CFF0 /* OAuth2SwiftCredential.swift in Sources */,
 				6053EF6F1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */,
+				5F4C097D1EFC1C8E0013CFF0 /* BaseOAuthSwiftSignatureMethod.swift in Sources */,
+				5F4C099E1EFC336A0013CFF0 /* HMAC_SHA1SignatureMethod.swift in Sources */,
 				F4E9A4E01A67944C00B4F3C8 /* OAuthSwiftHTTPRequest.swift in Sources */,
 				F47599B51A7903C9004A96C1 /* Int+OAuthSwift.swift in Sources */,
 				C42349991DCCE5F600BD980F /* OAuthSwiftResponse.swift in Sources */,
 				F4805E211A6BB5DD00F7677E /* Dictionary+OAuthSwift.swift in Sources */,
 				F47599B11A79001B004A96C1 /* Data+OAuthSwift.swift in Sources */,
 				C42D41BC1C1AD11600DEDF53 /* UIApplication+OAuthSwift.swift in Sources */,
+				5F4C097F1EFC1D150013CFF0 /* BaseOAuthSwiftVersion.swift in Sources */,
+				5F4C097A1EFC19580013CFF0 /* OAuthSwiftVersion.swift in Sources */,
+				5F4C09781EFC19150013CFF0 /* OAuthSwiftSignatureMethod.swift in Sources */,
 				C496246F1B00D6C30010BD09 /* OAuthWebViewController.swift in Sources */,
 				C4328F5F1DA151F800847FA3 /* Collection+OAuthSwift.swift in Sources */,
 			);

--- a/Sources/Credential/Concrete Credential Classes/HMAC_SHA1SignatureMethod.swift
+++ b/Sources/Credential/Concrete Credential Classes/HMAC_SHA1SignatureMethod.swift
@@ -1,0 +1,22 @@
+//
+//  HMAC_SHA1SignatureMethod.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+final class  HMAC_SHA1SignatureMethod: BaseOAuthSwiftSignatureMethod {
+    override var description: String {
+        return "HMAC-SHA1"
+    }
+    override func sign(key: Data, message: Data) -> Data? {
+        return HMAC.sha1(key: key, message: message)
+    }
+    override func sign(data: Data) -> Data? {
+        let mac = SHA1(data).calculate()
+        return Data(bytes: UnsafePointer<UInt8>(mac), count: mac.count)
+    }
+}

--- a/Sources/Credential/Concrete Credential Classes/OAuth1SwiftCredential.swift
+++ b/Sources/Credential/Concrete Credential Classes/OAuth1SwiftCredential.swift
@@ -1,0 +1,36 @@
+//
+//  OAuth1SwiftCredential.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+final class OAuth1SwiftCredential: BaseOAuthSwiftCredential {
+    
+    override func makeHeaders(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data? = nil) -> [String: String] {
+        var headers = [String: String]()
+        if let factory = headersFactory {
+            headers = factory.make(url, method: method, parameters: parameters, body: body)
+        }else {
+            headers = ["Authorization": self.authorizationHeader(method: method, url: url, parameters: parameters, body: body)];
+        }
+        return headers
+    }
+    
+    override func authorizationHeader(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data? = nil, timestamp: String, nonce: String) -> String {
+        let authorizationParameters = self.authorizationParametersWithSignature(method: method, url: url, parameters: parameters, body: body, timestamp: timestamp, nonce: nonce)
+        var parameterComponents = authorizationParameters.urlEncodedQuery.components(separatedBy: "&") as [String]
+        parameterComponents.sort { $0 < $1 }
+        var headerComponents = [String]()
+        for component in parameterComponents {
+            let subcomponent = component.components(separatedBy: "=") as [String]
+            if subcomponent.count == 2 {
+                headerComponents.append("\(subcomponent[0])=\"\(subcomponent[1])\"")
+            }
+        }
+        return "OAuth " + headerComponents.joined(separator: ", ")
+    }
+}

--- a/Sources/Credential/Concrete Credential Classes/OAuth1Version.swift
+++ b/Sources/Credential/Concrete Credential Classes/OAuth1Version.swift
@@ -1,0 +1,18 @@
+//
+//  OAuth1Version.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+final class OAuth1Version: BaseOAuthSwiftVersion {
+    override var description: String {
+        return "oauth1"
+    }
+    override var shortVersion: String {
+        return "1.0"
+    }
+}

--- a/Sources/Credential/Concrete Credential Classes/OAuth2SwiftCredential.swift
+++ b/Sources/Credential/Concrete Credential Classes/OAuth2SwiftCredential.swift
@@ -1,0 +1,27 @@
+//
+//  OAuth2SwiftCredential.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+final class OAuth2SwiftCredential: BaseOAuthSwiftCredential {
+    
+    override func makeHeaders(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data? = nil) -> [String: String] {
+        var headers = [String: String]()
+        if let factory = headersFactory {
+            headers = factory.make(url, method: method, parameters: parameters, body: body)
+        } else {
+            headers = self.oauthToken.isEmpty ? [:] : ["Authorization": "Bearer \(self.oauthToken)"]
+        }
+        return headers
+    }
+    
+    override func authorizationHeader(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data? = nil, timestamp: String, nonce: String) -> String {
+        // not used in OAuth 2.0
+        return ""
+    }
+}

--- a/Sources/Credential/Concrete Credential Classes/OAuth2Version.swift
+++ b/Sources/Credential/Concrete Credential Classes/OAuth2Version.swift
@@ -1,0 +1,18 @@
+//
+//  OAuth2Version.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+final class OAuth2Version: BaseOAuthSwiftVersion {
+    override var description: String {
+        return "oauth2"
+    }
+    override var shortVersion: String {
+        return "2.0"
+    }
+}

--- a/Sources/Credential/Credential Base Classes/BaseOAuthSwiftCredential.swift
+++ b/Sources/Credential/Credential Base Classes/BaseOAuthSwiftCredential.swift
@@ -1,101 +1,44 @@
 //
-//  OAuthSwiftCredential.swift
+//  BaseOAuthSwiftCredential.swift
 //  OAuthSwift
 //
-//  Created by Dongri Jin on 6/22/14.
-//  Copyright (c) 2014 Dongri Jin. All rights reserved.
+//  Created by Noam Bar-on on 6/21/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
 //
+
 import Foundation
 
-// Allow to customize computed headers
-public protocol OAuthSwiftCredentialHeadersFactory {
-    func make(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data?) -> [String: String]
-}
-
-// The credential for authentification
-open class OAuthSwiftCredential: NSObject, NSCoding {
-
-    public enum Version {
-        case oauth1, oauth2
-
-        public var shortVersion: String {
-            switch self {
-            case .oauth1:
-                return "1.0"
-            case .oauth2:
-                return "2.0"
-            }
-        }
-
-        public var signatureMethod: SignatureMethod {
-            return .HMAC_SHA1
-        }
-
-        var toInt32: Int32 {
-            switch self {
-            case .oauth1:
-                return 1
-            case .oauth2:
-                return 2
-            }
-        }
-        init(_ value: Int32) {
-            switch value {
-            case 1:
-                self = .oauth1
-            case 2:
-                self = .oauth2
-            default:
-                self = .oauth1
-            }
-        }
-    }
-
-    public enum SignatureMethod: String {
-        case HMAC_SHA1 = "HMAC-SHA1"//, RSA_SHA1 = "RSA-SHA1", PLAINTEXT = "PLAINTEXT"
-
-        func sign(key: Data, message: Data) -> Data? {
-            switch self {
-            case .HMAC_SHA1:
-                return HMAC.sha1(key: key, message: message)
-            }
-        }
-
-        func sign(data: Data) -> Data? {
-            switch self {
-            case .HMAC_SHA1:
-                let mac = SHA1(data).calculate()
-                return Data(bytes: UnsafePointer<UInt8>(mac), count: mac.count)
-            }
-        }
-    }
-
+// A base class with default implementation of OAuthSwiftCredential protocol
+public class BaseOAuthSwiftCredential: NSObject, OAuthSwiftCredential {
+    
     // MARK: attributes
-    var consumerKey = ""
-    var consumerSecret = ""
+    open var consumerKey = ""
+    open var consumerSecret = ""
     open var oauthToken = ""
     open var oauthRefreshToken = ""
     open var oauthTokenSecret = ""
     open var oauthTokenExpiresAt: Date?
-    open internal(set) var oauthVerifier = ""
-    open var version: Version = .oauth1
-
+    open var oauthVerifier = ""
+    open var version: OAuthSwiftVersion
+    
     // hook to replace headers creation
     open var headersFactory: OAuthSwiftCredentialHeadersFactory?
-
-    // MARK: init
-    override init() {
+    
+    override public init() {
+        self.version = OAuth1Version() // default
     }
-
-    public init(consumerKey: String, consumerSecret: String) {
+    
+    // MARK: init
+    public required init(consumerKey: String, consumerSecret: String, version: OAuthSwiftVersion) {
         self.consumerKey = consumerKey
         self.consumerSecret = consumerSecret
+        self.version = version
     }
-
+    
     // MARK: NSCoding protocol
     fileprivate struct CodingKeys {
         static let bundleId = Bundle.main.bundleIdentifier
-            ?? Bundle(for: OAuthSwiftCredential.self).bundleIdentifier
+            ?? Bundle(for: BaseOAuthSwiftCredential.self).bundleIdentifier
             ?? ""
         static let base = bundleId + "."
         static let consumerKey = base + "comsumer_key"
@@ -107,9 +50,8 @@ open class OAuthSwiftCredential: NSObject, NSCoding {
         static let oauthVerifier = base + "oauth_verifier"
         static let version = base + "version"
     }
-
-    // Cannot declare a required initializer within an extension.
-    // extension OAuthSwiftCredential: NSCoding {
+    
+    // MARK: NSCoding
     public required convenience init?(coder decoder: NSCoder) {
         self.init()
         self.consumerKey = (decoder.decodeObject(forKey: CodingKeys.consumerKey) as? String) ?? String()
@@ -119,9 +61,9 @@ open class OAuthSwiftCredential: NSObject, NSCoding {
         self.oauthTokenSecret = (decoder.decodeObject(forKey: CodingKeys.oauthTokenSecret) as? String) ?? String()
         self.oauthVerifier = (decoder.decodeObject(forKey: CodingKeys.oauthVerifier) as? String) ?? String()
         self.oauthTokenExpiresAt = (decoder.decodeObject(forKey: CodingKeys.oauthTokenExpiresAt) as? Date)
-        self.version = Version(decoder.decodeInt32(forKey: CodingKeys.version))
+        self.version = (decoder.decodeObject(forKey: CodingKeys.version) as! OAuthSwiftVersion)
     }
-
+    
     open func encode(with coder: NSCoder) {
         coder.encode(self.consumerKey, forKey: CodingKeys.consumerKey)
         coder.encode(self.consumerSecret, forKey: CodingKeys.consumerSecret)
@@ -130,98 +72,76 @@ open class OAuthSwiftCredential: NSObject, NSCoding {
         coder.encode(self.oauthTokenSecret, forKey: CodingKeys.oauthTokenSecret)
         coder.encode(self.oauthVerifier, forKey: CodingKeys.oauthVerifier)
         coder.encode(self.oauthTokenExpiresAt, forKey: CodingKeys.oauthTokenExpiresAt)
-        coder.encode(self.version.toInt32, forKey: CodingKeys.version)
+        coder.encode(self.version, forKey: CodingKeys.version)
     }
-    // } // End NSCoding extension
-
+    // End NSCoding
+    
     // MARK: functions
     // for OAuth1 parameters must contains sorted query parameters and url must not contains query parameters
     open func makeHeaders(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data? = nil) -> [String: String] {
-        if let factory = headersFactory {
-            return factory.make(url, method: method, parameters: parameters, body: body)
-        }
-        switch self.version {
-        case .oauth1:
-            return ["Authorization": self.authorizationHeader(method: method, url: url, parameters: parameters, body: body)]
-        case .oauth2:
-            return self.oauthToken.isEmpty ? [:] : ["Authorization": "Bearer \(self.oauthToken)"]
-        }
+        preconditionFailure("This abstract method must be overridden")
     }
-
+    
     open func authorizationHeader(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data? = nil) -> String {
         let timestamp = String(Int64(Date().timeIntervalSince1970))
-        let nonce = OAuthSwiftCredential.generateNonce()
+        let nonce = BaseOAuthSwiftCredential.generateNonce()
         return self.authorizationHeader(method: method, url: url, parameters: parameters, body: body, timestamp: timestamp, nonce: nonce)
     }
-
+    
     open class func generateNonce() -> String {
         let uuidString = UUID().uuidString
         return uuidString.substring(to: 8)
     }
-
+    
     open func authorizationHeader(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data? = nil, timestamp: String, nonce: String) -> String {
-        assert(self.version == .oauth1)
-        let authorizationParameters = self.authorizationParametersWithSignature(method: method, url: url, parameters: parameters, body: body, timestamp: timestamp, nonce: nonce)
-
-        var parameterComponents = authorizationParameters.urlEncodedQuery.components(separatedBy: "&") as [String]
-        parameterComponents.sort { $0 < $1 }
-
-        var headerComponents = [String]()
-        for component in parameterComponents {
-            let subcomponent = component.components(separatedBy: "=") as [String]
-            if subcomponent.count == 2 {
-                headerComponents.append("\(subcomponent[0])=\"\(subcomponent[1])\"")
-            }
-        }
-
-        return "OAuth " + headerComponents.joined(separator: ", ")
+        preconditionFailure("This abstract method must be overridden")
     }
-
+    
     open func authorizationParametersWithSignature(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data? = nil) -> OAuthSwift.Parameters {
         let timestamp = String(Int64(Date().timeIntervalSince1970))
-        let nonce = OAuthSwiftCredential.generateNonce()
+        let nonce = BaseOAuthSwiftCredential.generateNonce()
         return self.authorizationParametersWithSignature(method: method, url: url, parameters: parameters, body: body, timestamp: timestamp, nonce: nonce)
     }
-
+    
     open func authorizationParametersWithSignature(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data? = nil, timestamp: String, nonce: String) -> OAuthSwift.Parameters {
         var authorizationParameters = self.authorizationParameters(body, timestamp: timestamp, nonce: nonce)
-
+        
         for (key, value) in parameters {
             if key.hasPrefix("oauth_") {
                 authorizationParameters.updateValue(value, forKey: key)
             }
         }
-
+        
         let combinedParameters = authorizationParameters.join(parameters)
-
+        
         authorizationParameters["oauth_signature"] = self.signature(method: method, url: url, parameters: combinedParameters)
-
+        
         return authorizationParameters
     }
-
+    
     open func authorizationParameters(_ body: Data?, timestamp: String, nonce: String) -> OAuthSwift.Parameters {
         var authorizationParameters = OAuthSwift.Parameters()
         authorizationParameters["oauth_version"] = self.version.shortVersion
-        authorizationParameters["oauth_signature_method"] =  self.version.signatureMethod.rawValue
+        authorizationParameters["oauth_signature_method"] =  "\(self.version.signatureMethod)"
         authorizationParameters["oauth_consumer_key"] = self.consumerKey
         authorizationParameters["oauth_timestamp"] = timestamp
         authorizationParameters["oauth_nonce"] = nonce
         if let b = body, let hash = self.version.signatureMethod.sign(data: b) {
             authorizationParameters["oauth_body_hash"] = hash.base64EncodedString(options: [])
         }
-
+        
         if !self.oauthToken.isEmpty {
             authorizationParameters["oauth_token"] = self.oauthToken
         }
         return authorizationParameters
     }
-
+    
     open func signature(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters) -> String {
         let encodedTokenSecret = self.oauthTokenSecret.urlEncodedString
         let encodedConsumerSecret = self.consumerSecret.urlEncodedString
-
+        
         let signingKey = "\(encodedConsumerSecret)&\(encodedTokenSecret)"
-
+        
         var parameterComponents = parameters.urlEncodedQuery.components(separatedBy: "&")
         parameterComponents.sort {
             let p0 = $0.components(separatedBy: "=")
@@ -229,26 +149,26 @@ open class OAuthSwiftCredential: NSObject, NSCoding {
             if p0.first == p1.first { return p0.last ?? "" < p1.last ?? "" }
             return p0.first ?? "" < p1.first ?? ""
         }
-
+        
         let parameterString = parameterComponents.joined(separator: "&")
         let encodedParameterString = parameterString.urlEncodedString
-
+        
         let encodedURL = url.absoluteString.urlEncodedString
-
+        
         let signatureBaseString = "\(method)&\(encodedURL)&\(encodedParameterString)"
-
+        
         let key = signingKey.data(using: .utf8)!
         let msg = signatureBaseString.data(using: .utf8)!
-
+        
         let sha1 = self.version.signatureMethod.sign(key: key, message: msg)!
         return sha1.base64EncodedString(options: [])
     }
-
+    
     open func isTokenExpired() -> Bool {
         if let expiresDate = oauthTokenExpiresAt {
             return expiresDate <= Date()
         }
-
+        
         // If no expires date is available we assume the token is still valid since it doesn't have an expiration date to check with.
         return false
     }

--- a/Sources/Credential/Credential Base Classes/BaseOAuthSwiftSignatureMethod.swift
+++ b/Sources/Credential/Credential Base Classes/BaseOAuthSwiftSignatureMethod.swift
@@ -1,0 +1,34 @@
+//
+//  BaseOAuthSwiftSignatureMethod.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+class  BaseOAuthSwiftSignatureMethod: NSObject, OAuthSwiftSignatureMethod {
+    override var description: String {
+        preconditionFailure("This abstract method must be overridden")
+        // return "HMAC-SHA1"
+    }
+    func sign(key: Data, message: Data) -> Data? {
+        preconditionFailure("This abstract method must be overridden")
+        // return HMAC.sha1(key: key, message: message)
+    }
+    func sign(data: Data) -> Data? {
+        preconditionFailure("This abstract method must be overridden")
+        // let mac = SHA1(data).calculate()
+        // return Data(bytes: UnsafePointer<UInt8>(mac), count: mac.count)
+    }
+    // MARK: init
+    override init() {
+    }
+    // MARK: NSCoding
+    func encode(with aCoder: NSCoder) {
+    }
+    public required convenience init?(coder decoder: NSCoder) {
+        self.init()
+    }
+}

--- a/Sources/Credential/Credential Base Classes/BaseOAuthSwiftVersion.swift
+++ b/Sources/Credential/Credential Base Classes/BaseOAuthSwiftVersion.swift
@@ -1,0 +1,38 @@
+//
+//  BaseOAuthSwiftVersion.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+class BaseOAuthSwiftVersion: NSObject, OAuthSwiftVersion {
+    override var description: String {
+        preconditionFailure("This abstract method must be overridden")
+        // return "oauth1"
+    }
+    var shortVersion: String {
+        preconditionFailure("This abstract method must be overridden")
+        //return "1.0"
+    }
+    var signatureMethod: OAuthSwiftSignatureMethod
+    
+    public convenience init(with signatureMethod: OAuthSwiftSignatureMethod) {
+        self.init()
+        self.signatureMethod = signatureMethod
+    }
+    // MARK: init
+    override init() {
+         self.signatureMethod = HMAC_SHA1SignatureMethod() // default
+    }
+    // MARK: NSCoding
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.signatureMethod, forKey: "signatureMethod")
+    }
+    public required convenience init?(coder decoder: NSCoder) {
+        self.init()
+        self.signatureMethod = (decoder.decodeObject(forKey: "signatureMethod") as! OAuthSwiftSignatureMethod)
+    }
+}

--- a/Sources/Credential/Credential Protocols/OAuthSwiftCredential.swift
+++ b/Sources/Credential/Credential Protocols/OAuthSwiftCredential.swift
@@ -1,0 +1,53 @@
+//
+//  OAuthSwiftCredential.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/21/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+// Allow to customize computed headers
+public protocol OAuthSwiftCredentialHeadersFactory {
+    func make(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data?) -> [String: String]
+}
+
+// Protocol for OAuthSwiftCredential object
+// For your convenience, find a concrete BaseOAuthSwiftCredential class you can subclass
+public protocol OAuthSwiftCredential: NSCoding, NSObjectProtocol {
+    
+    // MARK: attributes
+    var consumerKey: String {set get}
+    var consumerSecret: String {set get}
+    var oauthToken: String {set get}
+    var oauthRefreshToken: String {set get}
+    var oauthTokenSecret: String {set get}
+    var oauthTokenExpiresAt: Date? {set get}
+    var oauthVerifier: String {set get}
+    var version: OAuthSwiftVersion {set get}
+    
+    var headersFactory: OAuthSwiftCredentialHeadersFactory? {set get}
+    
+    init(consumerKey: String, consumerSecret: String, version: OAuthSwiftVersion)
+    
+    // MARK: functions
+    // for OAuth1 parameters must contains sorted query parameters and url must not contains query parameters
+    func makeHeaders(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data?) -> [String: String]
+    
+    func authorizationHeader(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data?) -> String
+    
+    static func generateNonce() -> String
+    
+    func authorizationHeader(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data?, timestamp: String, nonce: String) -> String
+    
+    func authorizationParametersWithSignature(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data?) -> OAuthSwift.Parameters
+    
+    func authorizationParametersWithSignature(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters, body: Data?, timestamp: String, nonce: String) -> OAuthSwift.Parameters
+    
+    func authorizationParameters(_ body: Data?, timestamp: String, nonce: String) -> OAuthSwift.Parameters
+    
+    func signature(method: OAuthSwiftHTTPRequest.Method, url: URL, parameters: OAuthSwift.Parameters) -> String
+    
+    func isTokenExpired() -> Bool
+}

--- a/Sources/Credential/Credential Protocols/OAuthSwiftSignatureMethod.swift
+++ b/Sources/Credential/Credential Protocols/OAuthSwiftSignatureMethod.swift
@@ -1,0 +1,17 @@
+//
+//  OAuthSwiftSignatureMethod.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+// Protocol for signature method object.
+// For your convenience, find below a concrete BaseSignatureMethod class you can subclass
+public protocol OAuthSwiftSignatureMethod: CustomStringConvertible, NSCoding, NSObjectProtocol {
+    var description: String {get}
+    func sign(key: Data, message: Data) -> Data?
+    func sign(data: Data) -> Data?
+}

--- a/Sources/Credential/Credential Protocols/OAuthSwiftVersion.swift
+++ b/Sources/Credential/Credential Protocols/OAuthSwiftVersion.swift
@@ -1,0 +1,17 @@
+//
+//  OAuthSwiftVersion.swift
+//  OAuthSwift
+//
+//  Created by Noam Bar-on on 6/22/17.
+//  Copyright © 2017 Dongri Jin. All rights reserved.
+//
+
+import Foundation
+
+// Protocol for version object
+// For your convenience, find BaseVersion class you can subclass
+public protocol OAuthSwiftVersion: CustomStringConvertible, NSCoding, NSObjectProtocol {
+    var description: String {get}
+    var shortVersion: String {get}
+    var signatureMethod: OAuthSwiftSignatureMethod {set get}
+}

--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -30,11 +30,10 @@ open class OAuth1Swift: OAuthSwift {
         self.requestTokenUrl = requestTokenUrl
         self.authorizeUrl = authorizeUrl
         self.accessTokenUrl = accessTokenUrl
-        super.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
-        self.client.credential.version = .oauth1
+        super.init(consumerKey: consumerKey, consumerSecret: consumerSecret, credential: OAuth1SwiftCredential())
     }
 
-    public convenience override init(consumerKey: String, consumerSecret: String) {
+    public convenience init(consumerKey: String, consumerSecret: String) {
         self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, requestTokenUrl: "", authorizeUrl: "", accessTokenUrl: "")
     }
 

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -45,8 +45,7 @@ open class OAuth2Swift: OAuthSwift {
         self.consumerSecret = consumerSecret
         self.authorizeUrl = authorizeUrl
         self.responseType = responseType
-        super.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
-        self.client.credential.version = .oauth2
+        super.init(consumerKey: consumerKey, consumerSecret: consumerSecret, credential: OAuth2SwiftCredential())
     }
 
     public convenience init?(parameters: ConfigParameters) {

--- a/Sources/OAuthSwift.swift
+++ b/Sources/OAuthSwift.swift
@@ -15,7 +15,7 @@ open class OAuthSwift: NSObject, OAuthSwiftRequestHandle {
     // Client to make signed request
     open var client: OAuthSwiftClient
     // Version of the protocol
-    open var version: OAuthSwiftCredential.Version { return self.client.credential.version }
+    open var version: OAuthSwiftVersion { return self.client.credential.version }
 
     // Handle the authorize url into a web view or browser
     open var authorizeURLHandler: OAuthSwiftURLHandlerType = OAuthSwiftOpenURLExternally.sharedInstance
@@ -23,8 +23,8 @@ open class OAuthSwift: NSObject, OAuthSwiftRequestHandle {
     fileprivate var currentRequests: [String: OAuthSwiftRequestHandle] = [:]
 
     // MARK: init
-    init(consumerKey: String, consumerSecret: String) {
-        self.client = OAuthSwiftClient(consumerKey: consumerKey, consumerSecret: consumerSecret)
+    init(consumerKey: String, consumerSecret: String, credential: OAuthSwiftCredential) {
+        self.client = OAuthSwiftClient(consumerKey: consumerKey, consumerSecret: consumerSecret, credential: credential)
     }
 
     // MARK: callback notification

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -16,7 +16,7 @@ var OAuthSwiftDataEncoding: String.Encoding = .utf8
 
 open class OAuthSwiftClient: NSObject {
 
-    fileprivate(set) open var credential: OAuthSwiftCredential
+    open var credential: OAuthSwiftCredential
     open var paramsLocation: OAuthSwiftHTTPRequest.ParamsLocation = .authorizationHeader
     // Contains default URL session configuration
     open var sessionFactory = URLSessionFactory()
@@ -30,19 +30,19 @@ open class OAuthSwiftClient: NSObject {
     public init(credential: OAuthSwiftCredential) {
         self.credential = credential
     }
-
-    public convenience init(consumerKey: String, consumerSecret: String, version: OAuthSwiftCredential.Version = .oauth1) {
-        let credential = OAuthSwiftCredential(consumerKey: consumerKey, consumerSecret: consumerSecret)
-        credential.version = version
+    
+    public convenience init(consumerKey: String, consumerSecret: String, credential: OAuthSwiftCredential) {
         self.init(credential: credential)
+        self.credential.consumerKey = consumerKey
+        self.credential.consumerSecret = consumerSecret
     }
-
-    public convenience init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String, version: OAuthSwiftCredential.Version) {
-        self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, version: version)
+    
+    public convenience init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String, credential: OAuthSwiftCredential) {
+        self.init(consumerKey: consumerKey, consumerSecret: consumerSecret, credential: credential)
         self.credential.oauthToken = oauthToken
         self.credential.oauthTokenSecret = oauthTokenSecret
     }
-
+    
     // MARK: client methods
     @discardableResult
     open func get(_ urlString: String, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil, success: OAuthSwiftHTTPRequest.SuccessHandler?, failure: OAuthSwiftHTTPRequest.FailureHandler?) -> OAuthSwiftRequestHandle? {


### PR DESCRIPTION
This refactors OAuthSwiftCredentials to be more flexible and extendable. No underlying implementation changed.
 
It uses a protocol based approach with base classes that implement common functionality, and concrete subclasses for specific credentials. This approach allows easy adjustment and enhancement and lays the ground for RSA support (That will follow in next PR). 

OAuthSwiftCredentials is broken down into 3 protocols (OAuthSwiftCredential, OAuthSwiftSignatureMethod and OAuthSwiftVersion), There are also 3 base classes respectfully implementing common aspects of the protocols, and concrete classes for OAuth1, OAuth2 and HMAC-SHA1 that implement the specific parts. 

Next PR will add RSA-SHA1 signatureMethod to extend functionality.
