### PR TITLE
Retrieving only authentication code by specifying response_type as code

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -103,7 +103,7 @@ open class OAuth2Swift: OAuthSwift {
                         return
                     }
                 }
-                if let handle = this.postOAuthAccessTokenWithRequestToken(
+                if let handle = this.exchangeCodeForAccessToken(
                     byCode: code.safeStringByRemovingPercentEncoding,
                     callbackURL: callbackURL, headers: headers, success: success, failure: failure) {
                     this.putHandle(handle, withKey: UUID().uuidString)
@@ -157,7 +157,7 @@ open class OAuth2Swift: OAuthSwift {
         return authorize(withCallbackURL: url, scope: scope, state: state, parameters: parameters, headers: headers, success: success, failure: failure)
     }
 
-    func postOAuthAccessTokenWithRequestToken(byCode code: String, callbackURL: URL, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
+    open func exchangeCodeForAccessToken(byCode code: String, callbackURL: URL, headers: OAuthSwift.Headers? = nil, success: @escaping TokenSuccessHandler, failure: FailureHandler?) -> OAuthSwiftRequestHandle? {
         var parameters = OAuthSwift.Parameters()
         parameters["client_id"] = self.consumerKey
         parameters["client_secret"] = self.consumerSecret


### PR DESCRIPTION
Fixes for enhancement #400

I made it open and changed the base class name to exchangeCodeForAccessToken. I thought method needs a better name so use the new name. But if you think it's not necessary or does not match with your naming conventions please let me know.

Gist link on how to use
https://gist.github.com/uiroshan/89f9baea0a2678955bc672bfcefbfebd