### PR TITLE
Remove unnecessary swiftlint comment

### DIFF
--- a/Sources/String+OAuthSwift.swift
+++ b/Sources/String+OAuthSwift.swift
@@ -102,7 +102,6 @@ extension String.Encoding {
 
     var charset: String {
         let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(self.rawValue))
-        // swiftlint:disable force_cast
         return charset! as String
     }
 


### PR DESCRIPTION
It's not necessary to disable force_cast here as the code is not causing a force_cast error.

This is actually causing my Carthage build to fail. :cry:

See Issue: [#407](https://github.com/OAuthSwift/OAuthSwift/issues/407) 