### PR TITLE
remove String.characters warnings

### DIFF
--- a/OAuthSwiftTests/UtilsTests.swift
+++ b/OAuthSwiftTests/UtilsTests.swift
@@ -44,7 +44,7 @@ class UtilsTest: XCTestCase {
     func testGenerateState() {
         for l  in 0 ..< 20 {
             let str = generateState(withLength: l)
-            XCTAssertEqual(str.characters.count, l)
+            XCTAssertEqual(str.count, l)
         }
     }
     

--- a/Sources/String+OAuthSwift.swift
+++ b/Sources/String+OAuthSwift.swift
@@ -46,7 +46,7 @@ extension String {
         var string = self
 
         if hasPrefix(elementSeparator) {
-            string = String(characters.dropFirst(1))
+            string = String(dropFirst(1))
         }
 
         var parameters = [String: String]()

--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public func generateState(withLength len: Int) -> String {
     let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    let length = UInt32(letters.characters.count)
+    let length = UInt32(letters.count)
 
     var randomString = ""
     for _ in 0..<len {
         let rand = arc4random_uniform(length)
         let idx = letters.index(letters.startIndex, offsetBy: Int(rand))
-        let letter = letters.characters[idx]
+        let letter = letters[idx]
         randomString += String(letter)
     }
     return randomString


### PR DESCRIPTION
Remove `String.characters` warnings from Swift 3.x