### PR TITLE
Enable `swift build` by SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.0
 // Package.swift
 /*
  The MIT License (MIT)
@@ -22,5 +23,12 @@
 import PackageDescription
 
 let package = Package(
-  name: "OAuthSwift"
+    name: "OAuthSwift",
+    products: [
+        .library(name: "OAuthSwift", targets: ["OAuthSwift"]),
+    ],
+    targets: [
+        .target(name: "OAuthSwift", dependencies: [], path: "Sources"),
+        .testTarget(name: "OAuthSwiftTests", dependencies: ["OAuthSwift"], path: "OAuthSwiftTests"),
+    ]
 )


### PR DESCRIPTION
It enables `swift build`.

Currently `swift build` fails for the `master` branch ( 9a8536d8a8f9d6673fe622f9bfb59e9c79334bcb ). Package.swift needs to be updated.

```
$ swift build
Compile Swift Module 'OAuthSwift' (24 sources)
/path/to/OAuthSwift/Sources/OAuthSwiftURLHandlerType.swift:36:25: error: method 'shared' was used as a property; add () to call it
            NSWorkspace.shared.open(url)
                        ^
                              ()
/path/to/OAuthSwift/Sources/OAuthSwiftHTTPRequest.swift:239:42: error: 'filter' is unavailable
            finalParameters = parameters.filter { key, _ in !key.hasPrefix("oauth_") }
                                         ^~~~~~
Swift.Dictionary:390:17: note: 'filter' was introduced in Swift 4.0
    public func filter(_ isIncluded: (Dictionary.Element) throws -> Bool) rethrows -> [Dictionary.Key : Dictionary.Value]
                ^
/path/to/OAuthSwift/Sources/OAuthWebViewController.swift:123:52: error: argument labels '(rawValue:)' do not match any available overloads
                    p.performSegue(withIdentifier: NSStoryboardSegue.Identifier(rawValue: segueIdentifier), sender: self) // The segue must display self.view
                                                   ^                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/OAuthSwift/Sources/OAuthWebViewController.swift:123:52: note: overloads for 'NSStoryboardSegue.Identifier' exist with these partially matching parameter lists: (coder: NSCoder), (stringLiteral: StaticString), (format: NSString, CVarArg...), (string: NSString), (utf8String: UnsafePointer<Int8>), (UTF8String: UnsafePointer<Int8>), (string: String), (contentsOfFile: String), (contentsOf: URL), (contentsOfURL: URL), (cString: UnsafePointer<Int8>), (CString: UnsafePointer<Int8>)
                    p.performSegue(withIdentifier: NSStoryboardSegue.Identifier(rawValue: segueIdentifier), sender: self) // The segue must display self.view
                                                   ^
error: terminated(1): /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-build-tool -f /path/to/OAuthSwift/.build/debug.yaml main
```

**NOTE:** Even after this PR is merged, `swift test` still fails to build the tests because it lacks dependencies on Swifter and Erik. Although I tried to add those dependencies to Package.swift, 

- OAuthSwift/swifter could not be built by SwiftPM
- original httpswift/swifter could be build by Swift PM, but I am not sure if it is OK to change the dependency
- Erik could not be build by SwiftPM

and so I gave up.