### PR TITLE
Fix incorrect coding key for signatureMethod on OAuthSwiftCredential when using a version of .oAuth1

### DIFF
--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -163,7 +163,7 @@ open class OAuthSwiftCredential: NSObject, NSCoding {
         coder.encode(self.oauthTokenExpiresAt, forKey: CodingKeys.oauthTokenExpiresAt)
         coder.encode(self.version.toInt32, forKey: CodingKeys.version)
         if case .oauth1 = version {
-            coder.encode(self.signatureMethod.rawValue, forKey: CodingKeys.version)
+            coder.encode(self.signatureMethod.rawValue, forKey: CodingKeys.signatureMethod)
         }
     }
     // } // End NSCoding extension


### PR DESCRIPTION
The encode method was writing the value for `signatureMethod` to the key that was reserved for version. There was a type mismatch of `String` and `Int32` which causes a crash on decode.