### PR TITLE
- SafariURLHandler now referencing oauthSwift as weak var Fix #451 

### DIFF
--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -47,7 +47,7 @@ import SafariServices
 
         public typealias UITransion = (_ controller: SFSafariViewController, _ handler: SafariURLHandler) -> Void
 
-        open let oauthSwift: OAuthSwift
+        weak open var oauthSwift: OAuthSwift?
         open var present: UITransion
         open var dismiss: UITransion
         /// retains observers
@@ -123,7 +123,7 @@ import SafariServices
         /// Clear internal observers on authentification flow
         open func clearObservers() {
             clearLocalObservers()
-            self.oauthSwift.removeCallbackNotificationObserver()
+            self.oauthSwift?.removeCallbackNotificationObserver()
         }
 
         open func clearLocalObservers() {


### PR DESCRIPTION
(was strong let) to prevent retention cycle with OAuthSwift

Tested with single oAuth2.0 provider using SafariURLHandler.