### PR TITLE
Fix failing oauth1 tests Fix #460

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - PROJECT=OAuthSwift.xcodeproj
     - IOS_FRAMEWORK_SCHEME="OAuthSwift"
     - MACOS_FRAMEWORK_SCHEME="OAuthSwiftOSX"
-    - IOS_SDK=iphonesimulator11.0
+    - IOS_SDK=iphonesimulator11.3
     - MACOS_SDK=macosx10.13
   matrix:
     - DESTINATION="OS=11.0,name=iPhone 8" SCHEME="$IOS_FRAMEWORK_SCHEME" SDK="$IOS_SDK"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'cocoapods'
 gem 'xcpretty'
 gem 'danger'
 gem 'danger-swiftlint'

--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -79,7 +79,7 @@ open class OAuth1Swift: OAuthSwift {
                     responseParameters["oauth_token"] = token
                 }
 
-                if let token = responseParameters["oauth_token"] {
+                if let token = responseParameters["oauth_token"], !token.isEmpty {
                     this.client.credential.oauthToken = token.safeStringByRemovingPercentEncoding
                     if let oauth_verifier = responseParameters["oauth_verifier"] {
                         this.client.credential.oauthVerifier = oauth_verifier.safeStringByRemovingPercentEncoding


### PR DESCRIPTION
oauthbin is returning a 200 response with string data that explains the failure rather than a 400. The authorize method in this case is just using the OAuthSwiftCredential's default token value, which is an empty string. This change makes a response with an empty token value report as a `missingToken` error.

Fixes #460 