### PR TITLE
OAuthSwiftCredential  conforms to NSSecureCoding 

### DIFF
--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -109,8 +109,8 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
     }
 
     // MARK: attributes
-    public let consumerKey: String
-    public let consumerSecret: String
+    open internal(set) var consumerKey = ""
+    open internal(set) var consumerSecret = ""
     open var oauthToken = ""
     open var oauthRefreshToken = ""
     open var oauthTokenSecret = ""
@@ -121,6 +121,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
 
     /// hook to replace headers creation
     open var headersFactory: OAuthSwiftCredentialHeadersFactory?
+
+    // MARK: init
+    override init() {
+    }
 
     public init(consumerKey: String, consumerSecret: String) {
         self.consumerKey = consumerKey

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -271,10 +271,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
     public required convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let consumerKey = try container.decode(String.self, forKey: .consumerKey)
-        let consumerSecret = try container.decode(String.self, forKey: .consumerSecret)
+        self.init()
 
-        self.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
+        self.consumerKey = try container.decode(String.self, forKey: .consumerKey)
+        self.consumerSecret = try container.decode(String.self, forKey: .consumerSecret)
 
         self.oauthToken = try container.decode(type(of: self.oauthToken), forKey: .oauthToken)
         self.oauthRefreshToken = try container.decode(type(of: self.oauthRefreshToken), forKey: .oauthRefreshToken)

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -35,7 +35,9 @@ public enum OAuthSwiftHashMethod: String {
 }
 
 /// The credential for authentification
-open class OAuthSwiftCredential: NSObject, NSCoding, Codable {
+open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
+
+    public static let supportsSecureCoding = true
 
     public enum Version: Codable {
         case oauth1, oauth2
@@ -150,16 +152,65 @@ open class OAuthSwiftCredential: NSObject, NSCoding, Codable {
     /// extension OAuthSwiftCredential: NSCoding {
     public required convenience init?(coder decoder: NSCoder) {
         self.init()
-        self.consumerKey = (decoder.decodeObject(forKey: NSCodingKeys.consumerKey) as? String) ?? String()
-        self.consumerSecret = (decoder.decodeObject(forKey: NSCodingKeys.consumerSecret) as? String) ?? String()
-        self.oauthToken = (decoder.decodeObject(forKey: NSCodingKeys.oauthToken) as? String) ?? String()
-        self.oauthRefreshToken = (decoder.decodeObject(forKey: NSCodingKeys.oauthRefreshToken) as? String) ?? String()
-        self.oauthTokenSecret = (decoder.decodeObject(forKey: NSCodingKeys.oauthTokenSecret) as? String) ?? String()
-        self.oauthVerifier = (decoder.decodeObject(forKey: NSCodingKeys.oauthVerifier) as? String) ?? String()
-        self.oauthTokenExpiresAt = (decoder.decodeObject(forKey: NSCodingKeys.oauthTokenExpiresAt) as? Date)
+        guard let consumerKey = decoder
+            .decodeObject(of: NSString.self,
+                          forKey: NSCodingKeys.consumerKey) as String? else {
+            let error = CocoaError.error(.coderValueNotFound)
+            decoder.failWithError(error)
+            return nil
+        }
+        self.consumerKey = consumerKey
+
+        guard let consumerSecret = decoder
+            .decodeObject(of: NSString.self,
+                          forKey: NSCodingKeys.consumerSecret) as String? else {
+            let error = CocoaError.error(.coderValueNotFound)
+            decoder.failWithError(error)
+            return nil
+        }
+        self.consumerSecret = consumerSecret
+
+        guard let oauthToken = decoder
+            .decodeObject(of: NSString.self,
+                          forKey: NSCodingKeys.oauthToken) as String? else {
+            let error = CocoaError.error(.coderValueNotFound)
+            decoder.failWithError(error)
+            return nil
+        }
+        self.oauthToken = oauthToken
+
+        guard let oauthRefreshToken = decoder
+            .decodeObject(of: NSString.self,
+                          forKey: NSCodingKeys.oauthRefreshToken) as String? else {
+            let error = CocoaError.error(.coderValueNotFound)
+            decoder.failWithError(error)
+            return nil
+        }
+        self.oauthRefreshToken = oauthRefreshToken
+
+        guard let oauthTokenSecret = decoder
+            .decodeObject(of: NSString.self,
+                          forKey: NSCodingKeys.oauthTokenSecret) as String? else {
+            let error = CocoaError.error(.coderValueNotFound)
+            decoder.failWithError(error)
+            return nil
+        }
+        self.oauthTokenSecret = oauthTokenSecret
+
+        guard let oauthVerifier = decoder
+            .decodeObject(of: NSString.self,
+                          forKey: NSCodingKeys.oauthVerifier) as String? else {
+            let error = CocoaError.error(.coderValueNotFound)
+            decoder.failWithError(error)
+            return nil
+        }
+        self.oauthVerifier = oauthVerifier
+
+        self.oauthTokenExpiresAt = decoder
+            .decodeObject(of: NSDate.self, forKey: NSCodingKeys.oauthTokenExpiresAt) as Date?
         self.version = Version(decoder.decodeInt32(forKey: NSCodingKeys.version))
         if case .oauth1 = version {
-            self.signatureMethod = SignatureMethod(rawValue: decoder.decodeObject(forKey: NSCodingKeys.signatureMethod) as? String ?? "HMAC_SHA1") ?? .HMAC_SHA1
+            self.signatureMethod = SignatureMethod(rawValue: (decoder.decodeObject(of: NSString.self, forKey: NSCodingKeys.signatureMethod) as String?) ?? "HMAC_SHA1") ?? .HMAC_SHA1
         }
     }
 

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -109,8 +109,8 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
     }
 
     // MARK: attributes
-    open internal(set) var consumerKey = ""
-    open internal(set) var consumerSecret = ""
+    public let consumerKey: String
+    public let consumerSecret: String
     open var oauthToken = ""
     open var oauthRefreshToken = ""
     open var oauthTokenSecret = ""
@@ -121,10 +121,6 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
 
     /// hook to replace headers creation
     open var headersFactory: OAuthSwiftCredentialHeadersFactory?
-
-    // MARK: init
-    override init() {
-    }
 
     public init(consumerKey: String, consumerSecret: String) {
         self.consumerKey = consumerKey
@@ -151,7 +147,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
     /// Cannot declare a required initializer within an extension.
     /// extension OAuthSwiftCredential: NSCoding {
     public required convenience init?(coder decoder: NSCoder) {
-        self.init()
+        
         guard let consumerKey = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.consumerKey) as String? else {
@@ -159,7 +155,6 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
             decoder.failWithError(error)
             return nil
         }
-        self.consumerKey = consumerKey
 
         guard let consumerSecret = decoder
             .decodeObject(of: NSString.self,
@@ -168,7 +163,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
             decoder.failWithError(error)
             return nil
         }
-        self.consumerSecret = consumerSecret
+        self.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
 
         guard let oauthToken = decoder
             .decodeObject(of: NSString.self,
@@ -260,10 +255,11 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
     public required convenience init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        self.init()
+        let consumerKey = try container.decode(String.self, forKey: .consumerKey)
+        let consumerSecret = try container.decode(String.self, forKey: .consumerSecret)
 
-        self.consumerKey = try container.decode(type(of: self.consumerKey), forKey: .consumerKey)
-        self.consumerSecret = try container.decode(type(of: self.consumerSecret), forKey: .consumerSecret)
+        self.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
+
         self.oauthToken = try container.decode(type(of: self.oauthToken), forKey: .oauthToken)
         self.oauthRefreshToken = try container.decode(type(of: self.oauthRefreshToken), forKey: .oauthRefreshToken)
         self.oauthTokenSecret = try container.decode(type(of: self.oauthTokenSecret), forKey: .oauthTokenSecret)

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -151,7 +151,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let consumerKey = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.consumerKey) as String? else {
-            if #available(iOS 9, *) {
+            if #available(iOS 9, OSX 10.11, *) {
                 let error = CocoaError.error(.coderValueNotFound)
                 decoder.failWithError(error)
             }
@@ -161,7 +161,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let consumerSecret = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.consumerSecret) as String? else {
-            if #available(iOS 9, *) {
+            if #available(iOS 9, OSX 10.11, *) {
                 let error = CocoaError.error(.coderValueNotFound)
                 decoder.failWithError(error)
             }
@@ -172,7 +172,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthToken = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthToken) as String? else {
-            if #available(iOS 9, *) {
+            if #available(iOS 9, OSX 10.11, *) {
                 let error = CocoaError.error(.coderValueNotFound)
                 decoder.failWithError(error)
             }
@@ -183,7 +183,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthRefreshToken = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthRefreshToken) as String? else {
-            if #available(iOS 9, *) {
+            if #available(iOS 9, OSX 10.11, *) {
                 let error = CocoaError.error(.coderValueNotFound)
                 decoder.failWithError(error)
             }
@@ -194,7 +194,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthTokenSecret = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthTokenSecret) as String? else {
-            if #available(iOS 9, *) {
+            if #available(iOS 9, OSX 10.11, *) {
                 let error = CocoaError.error(.coderValueNotFound)
                 decoder.failWithError(error)
             }
@@ -205,7 +205,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthVerifier = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthVerifier) as String? else {
-            if #available(iOS 9, *) {
+            if #available(iOS 9, OSX 10.11, *) {
                     let error = CocoaError.error(.coderValueNotFound)
                     decoder.failWithError(error)
             }

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -147,20 +147,24 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
     /// Cannot declare a required initializer within an extension.
     /// extension OAuthSwiftCredential: NSCoding {
     public required convenience init?(coder decoder: NSCoder) {
-        
+
         guard let consumerKey = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.consumerKey) as String? else {
-            let error = CocoaError.error(.coderValueNotFound)
-            decoder.failWithError(error)
+            if #available(iOS 9, *) {
+                let error = CocoaError.error(.coderValueNotFound)
+                decoder.failWithError(error)
+            }
             return nil
         }
 
         guard let consumerSecret = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.consumerSecret) as String? else {
-            let error = CocoaError.error(.coderValueNotFound)
-            decoder.failWithError(error)
+            if #available(iOS 9, *) {
+                let error = CocoaError.error(.coderValueNotFound)
+                decoder.failWithError(error)
+            }
             return nil
         }
         self.init(consumerKey: consumerKey, consumerSecret: consumerSecret)
@@ -168,8 +172,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthToken = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthToken) as String? else {
-            let error = CocoaError.error(.coderValueNotFound)
-            decoder.failWithError(error)
+            if #available(iOS 9, *) {
+                let error = CocoaError.error(.coderValueNotFound)
+                decoder.failWithError(error)
+            }
             return nil
         }
         self.oauthToken = oauthToken
@@ -177,8 +183,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthRefreshToken = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthRefreshToken) as String? else {
-            let error = CocoaError.error(.coderValueNotFound)
-            decoder.failWithError(error)
+            if #available(iOS 9, *) {
+                let error = CocoaError.error(.coderValueNotFound)
+                decoder.failWithError(error)
+            }
             return nil
         }
         self.oauthRefreshToken = oauthRefreshToken
@@ -186,8 +194,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthTokenSecret = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthTokenSecret) as String? else {
-            let error = CocoaError.error(.coderValueNotFound)
-            decoder.failWithError(error)
+            if #available(iOS 9, *) {
+                let error = CocoaError.error(.coderValueNotFound)
+                decoder.failWithError(error)
+            }
             return nil
         }
         self.oauthTokenSecret = oauthTokenSecret
@@ -195,8 +205,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         guard let oauthVerifier = decoder
             .decodeObject(of: NSString.self,
                           forKey: NSCodingKeys.oauthVerifier) as String? else {
-            let error = CocoaError.error(.coderValueNotFound)
-            decoder.failWithError(error)
+            if #available(iOS 9, *) {
+                    let error = CocoaError.error(.coderValueNotFound)
+                    decoder.failWithError(error)
+            }
             return nil
         }
         self.oauthVerifier = oauthVerifier


### PR DESCRIPTION
Follow recommendations:
Translate All decodeObject(forKey:) Calls to decodeObject(of:forKey:)
in
https://developer.apple.com/videos/play/wwdc2018/222/

- decodeObject(forKey:) will be deprecated in iOS 12
- take care of compatibility with iOS 8 and OSX 10.10

Get rid of designated initializer with no arguments, consumerKey and consumerSecret attributes are now immutable