### PR TITLE
Add @nonobjc to topViewController in UIApplication extension to fix ld warning

### DIFF
--- a/Sources/UIApplication+OAuthSwift.swift
+++ b/Sources/UIApplication+OAuthSwift.swift
@@ -10,7 +10,7 @@
     import UIKit
 
     extension UIApplication {
-        static var topViewController: UIViewController? {
+        @nonobjc static var topViewController: UIViewController? {
             #if !OAUTH_APP_EXTENSIONS
                 return UIApplication.shared.topViewController
             #else


### PR DESCRIPTION
I don't know if it's something wrong in my project, but when I added last version of OAuthSwift via cocoapods, `ld` started emitting the following warning each time:

`
ld: warning: Some object files have incompatible Objective-C category definitions. Some category metadata may be lost. All files containing Objective-C categories should be built using the same compiler.`

With this addition the warning is gone.