### PR TITLE
Reduce macOS deployment target

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/*.swift'
   s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '3.0'
   s.requires_arc = false


### PR DESCRIPTION
As per #496, reduce the deployment target for macOS 10.10 as all APIs used are already available there.