### PR TITLE
Added support for macCatalyst

### DIFF
--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -45,13 +45,16 @@ import SafariServices
 import AuthenticationServices
 #endif
 
-    @available(iOS 12.0, UIKitForMac 13.0, *)
+    @available(iOS 13.0, UIKitForMac 13.0, *)
     open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
         var webAuthSession: ASWebAuthenticationSession!
         let callbackUrlScheme: String
 
-        public init(callbackUrlScheme: String) {
+        weak var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
+
+        public init(callbackUrlScheme: String, presentationContextProvider: ASWebAuthenticationPresentationContextProviding?) {
             self.callbackUrlScheme = callbackUrlScheme
+            self.presentationContextProvider = presentationContextProvider
         }
 
         public func handle(_ url: URL) {
@@ -71,6 +74,7 @@ import AuthenticationServices
                                                                 UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
                                                             #endif
             })
+            webAuthSession.presentationContextProvider = presentationContextProvider
 
             _ = webAuthSession.start()
         }

--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -50,7 +50,7 @@ import AuthenticationServices
         var webAuthSession: ASWebAuthenticationSession!
         let callbackUrlScheme: String
 
-        init(callbackUrlScheme: String) {
+        public init(callbackUrlScheme: String) {
             self.callbackUrlScheme = callbackUrlScheme
         }
 
@@ -82,7 +82,7 @@ import AuthenticationServices
         var webAuthSession: SFAuthenticationSession!
         let callbackUrlScheme: String
 
-        init(callbackUrlScheme: String) {
+        public init(callbackUrlScheme: String) {
             self.callbackUrlScheme = callbackUrlScheme
         }
 

--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -45,7 +45,7 @@ import SafariServices
 import AuthenticationServices
 #endif
 
-    @available(iOS 12.0, *)
+    @available(iOS 12.0, UIKitForMac 13.0, *)
     open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
         var webAuthSession: ASWebAuthenticationSession!
         let callbackUrlScheme: String
@@ -76,7 +76,8 @@ import AuthenticationServices
         }
     }
 
-    @available(iOS 11.0, *)
+    #if !targetEnvironment(UIKitForMac)
+    @available(iOS, introduced: 11.0, deprecated: 12.0)
     open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
         var webAuthSession: SFAuthenticationSession!
         let callbackUrlScheme: String
@@ -106,6 +107,7 @@ import AuthenticationServices
             _ = webAuthSession.start()
         }
     }
+    #endif
 
     @available(iOS 9.0, *)
     open class SafariURLHandler: NSObject, OAuthSwiftURLHandlerType, SFSafariViewControllerDelegate {

--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -45,7 +45,7 @@ import SafariServices
 import AuthenticationServices
 #endif
 
-    @available(iOS 13.0, UIKitForMac 13.0, *)
+    @available(iOS 13.0, macCatalyst 13.0, *)
     open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
         var webAuthSession: ASWebAuthenticationSession!
         let callbackUrlScheme: String
@@ -80,7 +80,7 @@ import AuthenticationServices
         }
     }
 
-    #if !targetEnvironment(UIKitForMac)
+#if !targetEnvironment(macCatalyst)
     @available(iOS, introduced: 11.0, deprecated: 12.0)
     open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
         var webAuthSession: SFAuthenticationSession!

--- a/Sources/OAuthWebViewController.swift
+++ b/Sources/OAuthWebViewController.swift
@@ -64,7 +64,7 @@ open class OAuthWebViewController: OAuthViewController, OAuthSwiftURLHandlerType
     public enum Present {
         case asModalWindow
         case asSheet
-        case asPopover(relativeToRect: NSRect, ofView : NSView, preferredEdge: NSRectEdge, behavior: NSPopover.Behavior)
+        case asPopover(relativeToRect: NSRect, ofView: NSView, preferredEdge: NSRectEdge, behavior: NSPopover.Behavior)
         case transitionFrom(fromViewController: NSViewController, options: NSViewController.TransitionOptions)
         case animator(animator: NSViewControllerPresentationAnimator)
         case segue(segueIdentifier: String)


### PR DESCRIPTION
I added support for UIKitForMac (renamed `macCatalyst` in beta 4 and beyond). In order for this to work, I also had to fix `ASWebAuthenticationURLHandler` as it was not actually publicly usable. macCatalyst forbids the use of any deprecated functions so this had to be fixed. 

Tested on macOS Catalina beta 4 and 5.