### PR TITLE
fire dismiss handler when safariViewControllerDidFinish(control…

### DIFF
--- a/Sources/Handler/SafariURLHandler.swift
+++ b/Sources/Handler/SafariURLHandler.swift
@@ -114,6 +114,7 @@ open class SafariURLHandler: NSObject, OAuthSwiftURLHandlerType, SFSafariViewCon
     public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         // "Done" pressed
         self.clearObservers()
+        self.dismiss(controller, self)
         self.delegate?.safariViewControllerDidFinish?(controller)
     }
 

--- a/Sources/Handler/SafariURLHandler.swift
+++ b/Sources/Handler/SafariURLHandler.swift
@@ -114,7 +114,7 @@ open class SafariURLHandler: NSObject, OAuthSwiftURLHandlerType, SFSafariViewCon
     public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         // "Done" pressed
         self.clearObservers()
-        self.dismiss(controller, self)
+        self.dismissCompletion?()
         self.delegate?.safariViewControllerDidFinish?(controller)
     }
 


### PR DESCRIPTION
I always use it conveniently. Thank you very much.

The dismiss completion did not work when the [DONE] button in Safari was tapped.
Since I had activated of UIActivityIndicatorView before transitioning to Safari, I needed dismissHandler to stop it.

I modified to work the dismissHandler when safariViewControllerDidFinish(:controller) fires.

Thank you for the review.