### PR TITLE
Includes all source subdirectories in pod spec with the recursive not…

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     'Eric Marchand' => 'eric.marchand.n7@gmail.com'
   }
   s.source = { git: 'https://github.com/OAuthSwift/OAuthSwift.git', tag: s.version }
-  s.source_files = 'Sources/*.swift'
+  s.source_files = 'Sources/**/*.swift'
   s.swift_versions = ['5.0', '5.1']
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
@phimage Hello, I did a new pull request according to the changes requested. The podpsec now uses the recursive notation, and this is the single commit of the PR. Please let me know if there is any other issue. Thanks