### PR TITLE
Add support for expired Twitter tokens

### DIFF
--- a/OAuthSwiftTests/OAuthSwiftErrorTest.swift
+++ b/OAuthSwiftTests/OAuthSwiftErrorTest.swift
@@ -25,6 +25,20 @@ class OAuthSwiftErrorTest: XCTestCase {
         XCTAssertTrue(((error as Error) as NSError).isExpiredToken)
 	}
 
+    func testDetectInvalidTokenFromTwitter() {
+        // given
+        let userInfo = [
+            NSURLErrorFailingURLErrorKey: "https://api.twitter.com/1.1/account/verify_credentials.json",
+            "Response-Body": "{\"errors\":[{\"code\":89,\"message\":\"Invalid or expired token.\"}]}"
+        ]
+        // Twitter error details are here: https://developer.twitter.com/en/docs/basics/response-codes
+        let error = NSError(domain: OAuthSwiftError.Domain, code: 401, userInfo: userInfo)
+
+        // assert
+        XCTAssertTrue(error.isExpiredToken)
+        XCTAssertTrue(((error as Error) as NSError).isExpiredToken)
+    }
+
     func testDetectInvalidTokensFromFacebook() {
         // given
         let createUserInfo = { (errorCode: Int, errorSubCode: Int?) -> [String:Any] in

--- a/Sources/NSError+OAuthSwift.swift
+++ b/Sources/NSError+OAuthSwift.swift
@@ -41,6 +41,10 @@ public extension NSError {
                     for error in errors {
                         if let errorType = error["errorType"] as? String, errorType == "invalid_token" || errorType == "expired_token" {
                             return true
+                        } else if let urlString = self.userInfo[NSURLErrorFailingURLErrorKey] as? String, urlString.contains("api.twitter.com"), let errorCode = error["code"] as? Int, errorCode == 89 {
+                            // This is the code for expired or invalid twitter token
+                            // see: https://developer.twitter.com/en/docs/basics/response-codes
+                            return true
                         }
                     }
                 }


### PR DESCRIPTION
See https://developer.twitter.com/en/docs/basics/response-codes

Twitter sends back errors in an errors array in the body, but it doesn't use any of the currently-supported method of indicating an expired or invalid token.