### PR TITLE
Fix new warnings when building with Xcode 11.4

### DIFF
--- a/Sources/HMAC.swift
+++ b/Sources/HMAC.swift
@@ -35,9 +35,12 @@ open class HMAC {
 
         let ipadAndMessageHash = SHA1(ipad + message).calculate()
         let mac = SHA1(opad + ipadAndMessageHash).calculate()
-
-        return Data(bytes: UnsafePointer<UInt8>(mac), count: mac.count)
-
+        var hashedData: Data? = nil
+        mac.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else { return }
+            hashedData = Data(bytes: baseAddress, count: mac.count)
+        }
+        return hashedData
     }
 
 }

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -296,7 +296,7 @@ open class OAuth2Swift: OAuthSwift {
                 case OAuthSwiftError.tokenExpired:
                     let renewCompletionHandler: TokenCompletionHandler = { result in
                         switch result {
-                        case .success(let credential, _, _):
+                        case .success(let (credential, _, _)):
                             // Ommit response parameters so they don't override the original ones
                             // We have successfully renewed the access token.
 

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -27,7 +27,12 @@ public enum OAuthSwiftHashMethod: String {
         switch self {
         case .sha1:
             let mac = SHA1(data).calculate()
-            return Data(bytes: UnsafePointer<UInt8>(mac), count: mac.count)
+            var hashedData: Data? = nil
+            mac.withUnsafeBufferPointer { pointer in
+                guard let baseAddress = pointer.baseAddress else { return }
+                hashedData = Data(bytes: baseAddress, count: mac.count)
+            }
+            return hashedData
         case .none:
             return data
         }


### PR DESCRIPTION
Xcode 11.4/Swift 5.2 came with a lot of changes in diagnostics, and there were a couple of warnings that popped up. I don't think there's anything risky here so hopefully it's helpful 😀