### PR TITLE
Added support for watchOS < 6.0

### DIFF
--- a/Sources/String+OAuthSwift.swift
+++ b/Sources/String+OAuthSwift.swift
@@ -54,7 +54,7 @@ extension String {
         let scanner = Scanner(string: string)
 
         while !scanner.isAtEnd {
-            if #available(iOS 13.0, OSX 10.15, *) {
+            if #available(iOS 13.0, OSX 10.15, watchOS 6.0, *) {
                 let key = scanner.scanUpToString(keyValueSeparator)
                 _ = scanner.scanString(keyValueSeparator)
 


### PR DESCRIPTION
Trying to build OAuthSwift for watchOS versions below 6.0 fail.
Adding the availability check fixes this problem. 