### PR TITLE
Don't send duplicate authentication with basic authentication

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -257,15 +257,18 @@ open class OAuth2Swift: OAuthSwift {
             return self.client.postMultiPartRequest(accessTokenUrl, method: .POST, parameters: parameters, headers: headers, checkTokenExpiration: false, completionHandler: completionHandler)
         } else {
             // special headers
+            var finalParameters = parameters
             var finalHeaders: OAuthSwift.Headers? = headers
             if accessTokenBasicAuthentification {
+                finalParameters.removeValue(forKey: "client_id")
+                finalParameters.removeValue(forKey: "client_secret")
                 let authentification = "\(self.consumerKey):\(self.consumerSecret)".data(using: String.Encoding.utf8)
                 if let base64Encoded = authentification?.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0)) {
                     finalHeaders += ["Authorization": "Basic \(base64Encoded)"] as OAuthSwift.Headers
                 }
             }
             // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
-            return self.client.request(accessTokenUrl, method: .POST, parameters: parameters, headers: finalHeaders, checkTokenExpiration: false, completionHandler: completionHandler)
+            return self.client.request(accessTokenUrl, method: .POST, parameters: finalParameters, headers: finalHeaders, checkTokenExpiration: false, completionHandler: completionHandler)
         }
     }
 


### PR DESCRIPTION
When enabling 
> accessTokenBasicAuthentification

The client_id and client_secret are still sent in the POST body. Some oAuth implementations complain about this. For example [Ory Hydra](https://github.com/ory/hydra) returns this error:
```
{
	"error": "invalid_client",
	"error_description": "Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method)",
	"error_hint": "The OAuth 2.0 Client supports client authentication method \"client_secret_basic\", but method \"client_secret_post\" was requested. You must configure the OAuth 2.0 client's \"token_endpoint_auth_method\" value to accept \"client_secret_post\".",
	"status_code": 401
}
```

This PR ensures that when authenticating through basic authentication, client_id and client_secret aren't sent in the post body.