### PR TITLE
Remove redundant URL initializer call from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ oauthswift = OAuth1Swift(
 )
 // authorize
 let handle = oauthswift.authorize(
-    withCallbackURL: URL(string: "oauth-swift://oauth-callback/twitter")!) { result in
+    withCallbackURL: "oauth-swift://oauth-callback/twitter") { result in
     switch result {
     case .success(let (credential, response, parameters)):
       print(credential.oauthToken)
@@ -153,7 +153,7 @@ oauthswift = OAuth2Swift(
     responseType:   "token"
 )
 let handle = oauthswift.authorize(
-    withCallbackURL: URL(string: "oauth-swift://oauth-callback/instagram")!,
+    withCallbackURL: "oauth-swift://oauth-callback/instagram",
     scope: "likes+comments", state:"INSTAGRAM") { result in
     switch result {
     case .success(let (credential, response, parameters)):
@@ -181,7 +181,7 @@ let codeVerifier = base64url("abcd...")
 let codeChallenge = codeChallenge(for: codeVerifier)
 
 let handle = oauthswift.authorize(
-    withCallbackURL: URL(string: "myApp://callback/")!,
+    withCallbackURL: "myApp://callback/",
     scope: "requestedScope", 
     state:"State01",
     codeChallenge: codeChallenge,


### PR DESCRIPTION
All these function calls take `URLConvertible` as an argument, and `String` is also `URLConvertible`. Thus `URL(string:)` initializer call is redundant and has a negative impact on readability of the example code in `README.md`.