### PR TITLE
Add option to set ephemeral session on ASWebAuthenticationSession

### DIFF
--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -15,7 +15,7 @@ import AuthenticationServices
 
 @available(iOS 13.0, macCatalyst 13.0, *)
 open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
-    var webAuthSession: ASWebAuthenticationSession!
+    open var webAuthSession: ASWebAuthenticationSession!
     let callbackUrlScheme: String
 
     weak var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?

--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -21,7 +21,7 @@ open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
 
     weak var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
 
-    public init(callbackUrlScheme: String, presentationContextProvider: ASWebAuthenticationPresentationContextProviding?, prefersEphemeralWebBrowserSession: Bool) {
+    public init(callbackUrlScheme: String, presentationContextProvider: ASWebAuthenticationPresentationContextProviding?, prefersEphemeralWebBrowserSession: Bool = false) {
         self.callbackUrlScheme = callbackUrlScheme
         self.presentationContextProvider = presentationContextProvider
         self.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession

--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -15,14 +15,16 @@ import AuthenticationServices
 
 @available(iOS 13.0, macCatalyst 13.0, *)
 open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
-    open var webAuthSession: ASWebAuthenticationSession!
+    var webAuthSession: ASWebAuthenticationSession!
+    let prefersEphemeralWebBrowserSession: Bool
     let callbackUrlScheme: String
 
     weak var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
 
-    public init(callbackUrlScheme: String, presentationContextProvider: ASWebAuthenticationPresentationContextProviding?) {
+    public init(callbackUrlScheme: String, presentationContextProvider: ASWebAuthenticationPresentationContextProviding?, prefersEphemeralWebBrowserSession: Bool) {
         self.callbackUrlScheme = callbackUrlScheme
         self.presentationContextProvider = presentationContextProvider
+        self.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
     }
 
     public func handle(_ url: URL) {
@@ -45,7 +47,8 @@ open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
                                                         #endif
         })
         webAuthSession.presentationContextProvider = presentationContextProvider
-
+        webAuthSession.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+        
         _ = webAuthSession.start()
     }
 }


### PR DESCRIPTION
This PR adds the option to set an ephemeral session on `ASWebAuthenticationSession`. This is a non-breaking change as the new property added to `ASWebAuthenticationURLHandler`'s initialiser has a default value of false.