### PR TITLE
Automatically refresh access tokens in OAuthSwiftClient

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -72,14 +72,14 @@ open class OAuth2Swift: OAuthSwift {
     // MARK: functions
     @discardableResult
     open func authorize(withCallbackURL callbackURL: URLConvertible?, scope: String, state: String, parameters: Parameters = [:], headers: OAuthSwift.Headers? = nil, completionHandler completion: @escaping TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
-      
+
         OAuthSwift.log?.trace("Start authorization ...")
         if let url = callbackURL, url.url == nil {
             completion(.failure(.encodingError(urlString: url.string)))
             return nil
         }
         self.observeCallback { [weak self] url in
-         
+
             OAuthSwift.log?.trace("Open application resource url: \(url.absoluteString)")
             guard let this = self else {
                 OAuthSwift.retainError(completion)
@@ -176,7 +176,7 @@ open class OAuth2Swift: OAuthSwift {
     }
 
     open func postOAuthAccessTokenWithRequestToken(byCode code: String, callbackURL: URL?, headers: OAuthSwift.Headers? = nil, completionHandler completion: @escaping TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
-      
+
         var parameters = OAuthSwift.Parameters()
         parameters["client_id"] = self.consumerKey
         parameters["code"] = code

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -200,83 +200,11 @@ open class OAuth2Swift: OAuthSwift {
 
     @discardableResult
     open func renewAccessToken(withRefreshToken refreshToken: String, parameters: OAuthSwift.Parameters? = nil, headers: OAuthSwift.Headers? = nil, completionHandler completion: @escaping TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
-        var parameters = parameters ?? OAuthSwift.Parameters()
-        parameters["client_id"] = self.consumerKey
-        parameters["client_secret"] = self.consumerSecret
-        parameters["refresh_token"] = refreshToken
-        parameters["grant_type"] = "refresh_token"
-        OAuthSwift.log?.trace("Renew access token, parameters: \(parameters)")
-        return requestOAuthAccessToken(withParameters: parameters, headers: headers, completionHandler: completion)
+        return self.client.renewAccessToken(accessTokenUrl: self.accessTokenUrl, withRefreshToken: refreshToken, parameters: parameters ?? OAuthSwift.Parameters(), headers: headers, completionHandler: completion)
     }
 
     fileprivate func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, completionHandler completion: @escaping TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
-        OAuthSwift.log?.trace("Request Oauth access token ...")
-        let completionHandler: OAuthSwiftHTTPRequest.CompletionHandler = { [weak self] result in
-            guard let this = self else {
-                OAuthSwift.retainError(completion)
-                return
-            }
-            switch result {
-            case .success(let response):
-                OAuthSwift.log?.trace("Oauth access token response ...")
-
-                let responseJSON: Any? = try? response.jsonObject(options: .mutableContainers)
-
-                let responseParameters: OAuthSwift.Parameters
-
-                if let jsonDico = responseJSON as? [String: Any] {
-                    responseParameters = jsonDico
-                } else {
-                    responseParameters = response.string?.parametersFromQueryString ?? [:]
-                }
-
-                guard let accessToken = responseParameters["access_token"] as? String else {
-                    let message = NSLocalizedString("Could not get Access Token", comment: "Due to an error in the OAuth2 process, we couldn't get a valid token.")
-                    OAuthSwift.log?.error("Could not get access token")
-                    completion(.failure(.serverError(message: message)))
-                    return
-                }
-
-                if let refreshToken = responseParameters["refresh_token"] as? String {
-                    this.client.credential.oauthRefreshToken = refreshToken.safeStringByRemovingPercentEncoding
-                }
-
-                if let expiresIn = responseParameters["expires_in"] as? String, let offset = Double(expiresIn) {
-                    this.client.credential.oauthTokenExpiresAt = Date(timeInterval: offset, since: Date())
-                } else if let expiresIn = responseParameters["expires_in"] as? Double {
-                    this.client.credential.oauthTokenExpiresAt = Date(timeInterval: expiresIn, since: Date())
-                }
-
-                this.client.credential.oauthToken = accessToken.safeStringByRemovingPercentEncoding
-                completion(.success((this.client.credential, response, responseParameters)))
-            case .failure(let error):
-                OAuthSwift.log?.error(error.localizedDescription)
-                completion(.failure(error))
-            }
-        }
-
-        guard let accessTokenUrl = accessTokenUrl else {
-            let message = NSLocalizedString("access token url not defined", comment: "access token url not defined with code type auth")
-            OAuthSwift.log?.error("Access token url not defined")
-            completion(.failure(.configurationError(message: message)))
-            return nil
-        }
-
-        if self.contentType == "multipart/form-data" {
-            // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
-            return self.client.postMultiPartRequest(accessTokenUrl, method: .POST, parameters: parameters, headers: headers, checkTokenExpiration: false, completionHandler: completionHandler)
-        } else {
-            // special headers
-            var finalHeaders: OAuthSwift.Headers? = headers
-            if accessTokenBasicAuthentification {
-                let authentification = "\(self.consumerKey):\(self.consumerSecret)".data(using: String.Encoding.utf8)
-                if let base64Encoded = authentification?.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0)) {
-                    finalHeaders += ["Authorization": "Basic \(base64Encoded)"] as OAuthSwift.Headers
-                }
-            }
-            // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
-            return self.client.request(accessTokenUrl, method: .POST, parameters: parameters, headers: finalHeaders, checkTokenExpiration: false, completionHandler: completionHandler)
-        }
+		return self.client.requestOAuthAccessToken(accessTokenUrl: self.accessTokenUrl, withParameters: parameters, headers: headers, contentType: self.contentType, accessTokenBasicAuthentification: self.accessTokenBasicAuthentification, completionHandler: completion)
     }
 
     /**

--- a/Sources/OAuthLogProtocol.swift
+++ b/Sources/OAuthLogProtocol.swift
@@ -9,26 +9,26 @@
 import Foundation
 
 /// Define the level of log types
-public enum OAuthLogLevel:Int {
+public enum OAuthLogLevel: Int {
    // basic level; prints debug, warn, and error statements
    case trace = 0
    // medium level; prints warn and error statements
    case warn
    // highest level; prints only error statements
    case error
-   
+
 }
 
 public protocol OAuthLogProtocol {
-   
-   var level:OAuthLogLevel { get }
-      
+
+   var level: OAuthLogLevel { get }
+
    /// basic level of print messages
    func trace<T>(_ message: @autoclosure () -> T, filename: String, line: Int, function: String)
-   
+
    /// medium level of print messages
    func warn<T>(_ message: @autoclosure () -> T, filename: String, line: Int, function: String)
-   
+
    /// highest level of print messages
    func error<T>(_ message: @autoclosure () -> T, filename: String, line: Int, function: String)
 }
@@ -42,26 +42,26 @@ extension OAuthLogProtocol {
          print("[TRACE] \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
       }
    }
-   
+
    public func warn<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.warn
       if level.rawValue >= logLevel.rawValue {
          print("[WARN] \(self) = \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
       }
    }
-   
+
    public func error<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.error
       if level.rawValue >= logLevel.rawValue {
          print("[ERROR] \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
       }
-      
+
    }
 }
 
 public struct OAuthDebugLogger: OAuthLogProtocol {
-   public let level:OAuthLogLevel
-   init(_ level:OAuthLogLevel){
+   public let level: OAuthLogLevel
+   init(_ level: OAuthLogLevel) {
       self.level = level
    }
 }

--- a/Sources/OAuthSwift.swift
+++ b/Sources/OAuthSwift.swift
@@ -112,12 +112,12 @@ extension OAuthSwift {
 
 // MARK: - Logging
 extension OAuthSwift {
-   
-   static var log:OAuthLogProtocol?
+
+   static var log: OAuthLogProtocol?
 
    /// Enables the log level
    /// And instantiates the log object
-   public static func setLogLevel(_ level: OAuthLogLevel){
+   public static func setLogLevel(_ level: OAuthLogLevel) {
       Self.log = OAuthDebugLogger(level)
       OAuthSwift.log?.trace("Logging enabled with level: \(level)")
    }

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -189,4 +189,129 @@ open class OAuthSwiftClient: NSObject {
         return data
     }
 
+    // MARK: Refresh Token
+	@discardableResult
+    open func renewAccessToken(accessTokenUrl: URLConvertible?, withRefreshToken refreshToken: String, parameters: OAuthSwift.Parameters? = nil, headers: OAuthSwift.Headers? = nil, contentType: String? = nil, accessTokenBasicAuthentification: Bool = false, completionHandler completion: @escaping OAuthSwift.TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
+        var parameters = parameters ?? OAuthSwift.Parameters()
+        parameters["client_id"] = self.credential.consumerKey
+        parameters["client_secret"] = self.credential.consumerSecret
+        parameters["refresh_token"] = refreshToken
+        parameters["grant_type"] = "refresh_token"
+        OAuthSwift.log?.trace("Renew access token, parameters: \(parameters)")
+		return requestOAuthAccessToken(accessTokenUrl: accessTokenUrl, withParameters: parameters, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, completionHandler: completion)
+    }
+
+    func requestOAuthAccessToken(accessTokenUrl: URLConvertible?, withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, contentType: String? = nil, accessTokenBasicAuthentification: Bool = false, completionHandler completion: @escaping OAuthSwift.TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
+        OAuthSwift.log?.trace("Request Oauth access token ...")
+        let completionHandler: OAuthSwiftHTTPRequest.CompletionHandler = { [weak self] result in
+            guard let this = self else {
+                OAuthSwift.retainError(completion)
+                return
+            }
+            switch result {
+            case .success(let response):
+                OAuthSwift.log?.trace("Oauth access token response ...")
+
+                let responseJSON: Any? = try? response.jsonObject(options: .mutableContainers)
+
+                let responseParameters: OAuthSwift.Parameters
+
+                if let jsonDico = responseJSON as? [String: Any] {
+                    responseParameters = jsonDico
+                } else {
+                    responseParameters = response.string?.parametersFromQueryString ?? [:]
+                }
+
+                guard let accessToken = responseParameters["access_token"] as? String else {
+                    let message = NSLocalizedString("Could not get Access Token", comment: "Due to an error in the OAuth2 process, we couldn't get a valid token.")
+                    OAuthSwift.log?.error("Could not get access token")
+                    completion(.failure(.serverError(message: message)))
+                    return
+                }
+
+                if let refreshToken = responseParameters["refresh_token"] as? String {
+                    this.credential.oauthRefreshToken = refreshToken.safeStringByRemovingPercentEncoding
+                }
+
+                if let expiresIn = responseParameters["expires_in"] as? String, let offset = Double(expiresIn) {
+                    this.credential.oauthTokenExpiresAt = Date(timeInterval: offset, since: Date())
+                } else if let expiresIn = responseParameters["expires_in"] as? Double {
+                    this.credential.oauthTokenExpiresAt = Date(timeInterval: expiresIn, since: Date())
+                }
+
+                this.credential.oauthToken = accessToken.safeStringByRemovingPercentEncoding
+                completion(.success((this.credential, response, responseParameters)))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+
+        guard let accessTokenUrl = accessTokenUrl else {
+            let message = NSLocalizedString("access token url not defined", comment: "access token url not defined with code type auth")
+            OAuthSwift.log?.error("Access token url not defined")
+            completion(.failure(.configurationError(message: message)))
+            return nil
+        }
+
+		if contentType == "multipart/form-data" {
+            // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
+            return self.postMultiPartRequest(accessTokenUrl, method: .POST, parameters: parameters, headers: headers, checkTokenExpiration: false, completionHandler: completionHandler)
+        } else {
+            // special headers
+            var finalHeaders: OAuthSwift.Headers? = headers
+            if accessTokenBasicAuthentification {
+                let authentification = "\(self.credential.consumerKey):\(self.credential.consumerSecret)".data(using: String.Encoding.utf8)
+                if let base64Encoded = authentification?.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0)) {
+                    finalHeaders += ["Authorization": "Basic \(base64Encoded)"] as OAuthSwift.Headers
+                }
+            }
+            // Request new access token by disabling check on current token expiration. This is safe because the implementation wants the user to retrieve a new token.
+            return self.request(accessTokenUrl, method: .POST, parameters: parameters, headers: finalHeaders, checkTokenExpiration: false, completionHandler: completionHandler)
+        }
+    }
+
+	open func requestWithAutomaticAccessTokenRenewal(url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters = [:], headers: OAuthSwift.Headers? = nil, contentType: String? = nil, accessTokenBasicAuthentification: Bool = false, accessTokenUrl: URLConvertible, onTokenRenewal: OAuthSwift.TokenRenewedHandler?, completionHandler completion: OAuthSwiftHTTPRequest.CompletionHandler?) {
+		self.request(url, method: method, parameters: parameters, headers: headers) { [weak self] result in
+			guard let this = self else {
+                OAuthSwift.retainError(completion)
+                return
+            }
+
+			switch result {
+			case .success(let response):
+				if let completion = completion {
+					completion(.success(response))
+				}
+
+			case .failure(let error):
+				switch error {
+				case OAuthSwiftError.tokenExpired:
+					if let onTokenRenewal = onTokenRenewal {
+						let renewCompletionHandler: OAuthSwift.TokenCompletionHandler = { result in
+							switch result {
+							case .success(let (credential, _, _)):
+								onTokenRenewal(.success(credential))
+								this.requestWithAutomaticAccessTokenRenewal(url: url, method: method, parameters: parameters, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, accessTokenUrl: accessTokenUrl, onTokenRenewal: nil, completionHandler: completion)
+							case .failure(let error):
+								if let completion = completion {
+									completion(.failure(.tokenExpired(error: error)))
+								}
+							}
+						}
+
+						_ = this.renewAccessToken(accessTokenUrl: accessTokenUrl, withRefreshToken: this.credential.oauthRefreshToken, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, completionHandler: renewCompletionHandler)
+					} else {
+						if let completion = completion {
+							completion(.failure(.tokenExpired(error: nil)))
+						}
+					}
+
+				default:
+					if let completion = completion {
+						completion(.failure(.tokenExpired(error: nil)))
+					}
+				}
+			}
+		}
+	}
 }

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -228,7 +228,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         if case .oauth1 = version {
             self.signatureMethod = SignatureMethod(rawValue: (decoder.decodeObject(of: NSString.self, forKey: NSCodingKeys.signatureMethod) as String?) ?? "HMAC_SHA1") ?? .HMAC_SHA1
         }
-      
+
         OAuthSwift.log?.trace("Credential object is decoded")
     }
 


### PR DESCRIPTION
# Summary

Access tokens have an expiration date but OAuthSwift doesn't automatically refresh access tokens by default.


This PR proposes a solution:
- that makes OAuthSwift automatically refresh access tokens when they expire
- which is opt-in by providing one simple convenient method
- containing the minimum amount of changes needed to avoid to break existing apps

Related links:
- Issue #217 
- PR #209 

Changes:
- Add a new function `requestWithAutomaticAccessTokenRenewal` in OAuthSwiftClient. When used, it automatically refreshes the access token if it expired and restart the query.
- Move the implementation for `renewAccessToken` and `requestOAuthAccessToken` from OAuth2Swift to OAuthSwiftClient. The methods `renewAccessToken` and `requestOAuthAccessToken` are still available in OAuth2Swift but they simply forward the call to OAuthSwiftClient to ensure that old apps don't need to be changed.


# Why?

I developed an application, called [Clatters](https://apps.apple.com/app/clatters/id1480930237), that needs to access various services relying on OAuth. Rather that creating my own OAuth library, I decided to use OAuthSwift as it perfectly fit my needs.

However I believe that OAuthSwift should automatically refresh access tokens when they expire. The app itself shouldn't have to implement the logic to handle expired token.

[Clatters](https://apps.apple.com/app/clatters/id1480930237) has been available in the iOS App Store since February 2020 and relies on the code written in this PR.



# Usage

You can call the convenient method `requestWithAutomaticAccessTokenRenewal` in OAuthSwiftClient with the correct parameters. If the access token expired, `requestWithAutomaticAccessTokenRenewal` will automatically renew the access token and retry the query. Here is an example to perform a query on Reddit: 

```
static func requestIdentity(client: OAuthSwiftClient) {
		client.requestWithAutomaticAccessTokenRenewal(url: URL(string: "https://oauth.reddit.com/api/v1/me")!, method: .GET, headers: nil, contentType: nil, accessTokenBasicAuthentification: true, accessTokenUrl: "https://www.reddit.com/api/v1/access_token", onTokenRenewal: nil) { (result) in
			switch result {
				case .success(let response):
					// Do something
					debugPrint("Received \(response)")
					break
				case .failure:
					// Fail nicely
					break
			}
		}
    }
```

# Notes

I wanted to keep the changes proposed in this PR really simple. As previously mentioned:

- this new feature is opt-in by using a convenient method.
- apps already using OAuthSwift shouldn't be affected and don't need to adopt the new API.
- no code has been removed or deprecated.

