### PR TITLE
handle SFAuthenticationSession/ASWebAuthenticationSession canceledLogin errors

### DIFF
--- a/Sources/Handler/SFAuthenticationURLHandler.swift
+++ b/Sources/Handler/SFAuthenticationURLHandler.swift
@@ -25,24 +25,35 @@ open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
 
     public func handle(_ url: URL) {
       OAuthSwift.log?.trace("SFAuthenticationURLHandler: init session with url: \(url.absoluteString)")
-        webAuthSession = SFAuthenticationSession(url: url,
-                                                 callbackURLScheme: callbackUrlScheme,
-                                                 completionHandler: { callback, error in
-                                                    guard error == nil, let successURL = callback else {
-                                                        let msg = error?.localizedDescription.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
-                                                        let urlString = "\(self.callbackUrlScheme)?error=\(msg ?? "UNKNOWN")"
-                                                        let url = URL(string: urlString)!
-                                                        #if !OAUTH_APP_EXTENSIONS
-                                                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                                                        #endif
-                                                        return
-                                                    }
-                                                    #if !OAUTH_APP_EXTENSIONS
-                                                    UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
-                                                    #endif
+        webAuthSession = SFAuthenticationSession(
+            url: url,
+            callbackURLScheme: callbackUrlScheme,
+            completionHandler: { callback, error in
+                if let error = error {
+                    let msg = error.localizedDescription.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+                    let errorDomain = (error as NSError).domain
+                    let errorCode = (error as NSError).code
+                    let urlString = "\(self.callbackUrlScheme)?error=\(msg ?? "UNKNOWN")&error_domain=\(errorDomain)&error_code=\(errorCode)"
+                    let url = URL(string: urlString)!
+                    #if !OAUTH_APP_EXTENSIONS
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    #endif
+                } else if let successURL = callback {
+                    #if !OAUTH_APP_EXTENSIONS
+                    UIApplication.shared.open(successURL, options: [:], completionHandler: nil)
+                    #endif
+                }
         })
 
         _ = webAuthSession.start()
+    }
+}
+
+@available(iOS, introduced: 11.0, deprecated: 12.0)
+extension SFAuthenticationURLHandler {
+    static func isCancelledError(domain: String, code: Int) -> Bool {
+        return domain == SFAuthenticationErrorDomain &&
+            code == SFAuthenticationError.canceledLogin.rawValue
     }
 }
 #endif

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -125,10 +125,30 @@ open class OAuth2Swift: OAuthSwift {
                     this.putHandle(handle, withKey: UUID().uuidString)
                 }
             } else if let error = responseParameters["error"] {
-                let description = responseParameters["error_description"] ?? ""
-                let message = NSLocalizedString(error, comment: description)
-                OAuthSwift.log?.error("Authorization failed with: \(description)")
-                completion(.failure(.serverError(message: message)))
+                let otherErrorBlock = {
+                    let description = responseParameters["error_description"] ?? ""
+                    let message = NSLocalizedString(error, comment: description)
+                    OAuthSwift.log?.error("Authorization failed with: \(description)")
+                    completion(.failure(.serverError(message: message)))
+                }
+                
+                // handling SFAuthenticationSession/ASWebAuthenticationSession canceledLogin errors
+                if let domain = responseParameters["error_domain"],
+                    let codeString = responseParameters["error_code"],
+                    let code = Int(codeString) {
+                    
+                    if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *),
+                        ASWebAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
+                        completion(.failure(.cancelled))
+                    } else if #available(iOS 11, *),
+                        SFAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
+                        completion(.failure(.cancelled))
+                    } else {
+                        otherErrorBlock()
+                    }
+                } else {
+                    otherErrorBlock()
+                }
             } else {
                 let message = "No access_token, no code and no error provided by server"
                 OAuthSwift.log?.error("Authorization failed with: \(message)")


### PR DESCRIPTION
Allows to properly distinguish canceled logins from errors when using SFAuthenticationSession or ASWebAuthenticationSession. To implement this I have to pass error domain and error code inside callback url.