### PR TITLE
Fix a warning due to a string interpolation with an optional value

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -249,7 +249,7 @@ open class OAuth2Swift: OAuthSwift {
     @discardableResult
     open func startAuthorizedRequest(_ url: URLConvertible, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, renewHeaders: OAuthSwift.Headers? = nil, body: Data? = nil, onTokenRenewal: TokenRenewedHandler? = nil, completionHandler completion: @escaping OAuthSwiftHTTPRequest.CompletionHandler) -> OAuthSwiftRequestHandle? {
 
-        OAuthSwift.log?.trace("Start authorized request, url: \(url.url?.absoluteString) ...")
+        OAuthSwift.log?.trace("Start authorized request, url: \(url.url?.absoluteString ?? "unknown") ...")
         let completionHandler: OAuthSwiftHTTPRequest.CompletionHandler = { result in
             switch result {
             case .success:


### PR DESCRIPTION
Fix a warning OAuth2Swift.swift:252:65: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?