### PR TITLE
Fix broken build when compiling for Mac Catalyst

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -137,6 +137,14 @@ open class OAuth2Swift: OAuthSwift {
                     let codeString = responseParameters["error_code"],
                     let code = Int(codeString) {
 
+#if targetEnvironment(macCatalyst)
+					if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *),
+                        ASWebAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
+                        completion(.failure(.cancelled))
+                    } else {
+                        otherErrorBlock()
+                    }
+#else
                     if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *),
                         ASWebAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
                         completion(.failure(.cancelled))
@@ -146,6 +154,7 @@ open class OAuth2Swift: OAuthSwift {
                     } else {
                         otherErrorBlock()
                     }
+#endif
                 } else {
                     otherErrorBlock()
                 }


### PR DESCRIPTION
The revision `42e18ec60f45e1f51585410cd63758c1b47574cc` introduced a build error when compiling for Mac Catalyst.

As you can see in `SFAuthenticationURLHandler.swift`, SFAuthenticationURLHandler is not defined on Catalyst:

```
#if !targetEnvironment(macCatalyst)
@available(iOS, introduced: 11.0, deprecated: 12.0)
open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
[...]
#endif
```

The proposed solution consists of using the same `#if targetEnvironment(macCatalyst)` to not use SFAuthenticationURLHandler when compiling for Catalyst.