### PR TITLE
Fix for compiling Mac Framework

### DIFF
--- a/OAuthSwift.xcodeproj/project.pbxproj
+++ b/OAuthSwift.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		014747E82212C8FF00255186 /* URLConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01611E90220CB798003B1E60 /* URLConvertible.swift */; };
 		01611E91220CB798003B1E60 /* URLConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01611E90220CB798003B1E60 /* URLConvertible.swift */; };
 		0738BC6B1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0738BC6A1EBA755C000FA2F2 /* OAuthSwiftCredentialTests.swift */; };
+		1735E2ED24C8C6E700B1CDBF /* OAuthLogProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2BD6BA2442549D00668073 /* OAuthLogProtocol.swift */; };
 		48942B5B2085DB5F00376BFA /* URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48942B5A2085DB5F00376BFA /* URLTests.swift */; };
 		6053EF6F1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
 		6053EF701E93832400EB28B3 /* NotificationCenter+OAuthSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053EF6E1E93821400EB28B3 /* NotificationCenter+OAuthSwift.swift */; };
@@ -1053,6 +1054,7 @@
 				C48B282A1AFA599A00C7DEF6 /* URL+OAuthSwift.swift in Sources */,
 				C44685AD236CA6C300272231 /* SFAuthenticationURLHandler.swift in Sources */,
 				C44685B2236CA6DB00272231 /* SafariURLHandler.swift in Sources */,
+				1735E2ED24C8C6E700B1CDBF /* OAuthLogProtocol.swift in Sources */,
 				C48B282C1AFA599A00C7DEF6 /* Data+OAuthSwift.swift in Sources */,
 				C48B28271AFA599A00C7DEF6 /* SHA1.swift in Sources */,
 				C40890D91C11D48300E3146A /* OAuthSwift.swift in Sources */,

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -145,6 +145,10 @@ open class OAuth2Swift: OAuthSwift {
                         otherErrorBlock()
                     }
 #else
+                    
+#if os(macOS)
+                    otherErrorBlock()
+#else
                     if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *),
                         ASWebAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
                         completion(.failure(.cancelled))
@@ -154,6 +158,7 @@ open class OAuth2Swift: OAuthSwift {
                     } else {
                         otherErrorBlock()
                     }
+#endif
 #endif
                 } else {
                     otherErrorBlock()


### PR DESCRIPTION
Unable to compile the Mac Framework Target in the latest build as per issue #661

I've popped in some platform-specific macros to remove the failing lines fro the Mac build, but I'm not sure if there are further implications from this change.

Also, OAuthLogProtocol.swift has been included in the Mac target for the framework