### PR TITLE
Fix for Issue #613 - Calling Convenience initialiser when subclassing…

### DIFF
--- a/Sources/OAuthSwift.swift
+++ b/Sources/OAuthSwift.swift
@@ -23,7 +23,7 @@ open class OAuthSwift: NSObject, OAuthSwiftRequestHandle {
     fileprivate var currentRequests: [String: OAuthSwiftRequestHandle] = [:]
 
     // MARK: init
-    init(consumerKey: String, consumerSecret: String) {
+    public init(consumerKey: String, consumerSecret: String) {
         self.client = OAuthSwiftClient(consumerKey: consumerKey, consumerSecret: consumerSecret)
     }
 


### PR DESCRIPTION
Fix for Issue #613 - Calling Convenience initialiser when subclassing OAuth2Swift fails from xcode 11.4 onwards

Could this be applied to the 2.0.0 branch to align with the `pod 'OAuthSwift', '~> 2.0.0'` and also to the 2.0.1 branch.