### PR TITLE
Set OAuthSwift pod version to 2.1.3

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'OAuthSwift'
-  s.version = '2.1.0'
+  s.version = '2.1.3'
   s.license = 'MIT'
   s.summary = 'Swift based OAuth library for iOS and macOS.'
   s.homepage = 'https://github.com/OAuthSwift/OAuthSwift'


### PR DESCRIPTION
This updates OAuthSwift version in `OAuthSwift.podspec` to 2.1.3, assuming this is the version to be used for the upcoming release.

OAuthSwift 2.1.2 has been already released and tagged, but since it was marked as 2.1.0 in podspec (https://github.com/OAuthSwift/OAuthSwift/blob/2.1.2/OAuthSwift.podspec) it can not now be used with CocoaPods. This can't be resolved without altering the tag, but, going forward, this commit ensures that upcoming 2.1.3 is going to have the right version in the `OAuthSwift.podspec` file and can be then published on CocoaPods.

Relates to issue: https://github.com/OAuthSwift/OAuthSwift/issues/615