### PR TITLE
Fix the signature format for PLAINTEXT

### DIFF
--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -400,6 +400,10 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         let encodedParameterString = parameterString.urlEncoded
 
         let encodedURL = url.absoluteString.urlEncoded
+        
+        guard self.signatureMethod != .PLAINTEXT else {
+            return "\(consumerSecret)&\(oauthTokenSecret)"
+        }
 
         let signatureBaseString = "\(method)&\(encodedURL)&\(encodedParameterString)"
 


### PR DESCRIPTION
I encountered an issue regarding the signature format when using PLAINTEXT as the signature method. And after doing some research and debugging, I found that OAuthSwift was formatting the signature incorrectly. 

While this may not be the best solution, I have tested it with the (private) api that uses PLAINTEXT, and that does fix the issue.

Just for reference, the signature format for plaintext is highlighted in the [Dropbox documentation](https://dropbox.tech/developers/using-oauth-1-0-with-the-plaintext-signature-method).