### PR TITLE
Conditionally omit consumer secret when refreshing token (Issue #625)

### DIFF
--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -200,8 +200,8 @@ open class OAuthSwiftClient: NSObject {
         parameters["refresh_token"] = refreshToken
         parameters["grant_type"] = "refresh_token"
 
-		// Omit the consumer secret if it's empty; this makes token renewal consistent with PKCE authorization.
-		if !self.credential.consumerSecret.isEmpty {
+        // Omit the consumer secret if it's empty; this makes token renewal consistent with PKCE authorization.
+        if !self.credential.consumerSecret.isEmpty {
             parameters["client_secret"] = self.credential.consumerSecret
         }
 

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -194,9 +194,14 @@ open class OAuthSwiftClient: NSObject {
     open func renewAccessToken(accessTokenUrl: URLConvertible?, withRefreshToken refreshToken: String, parameters: OAuthSwift.Parameters? = nil, headers: OAuthSwift.Headers? = nil, contentType: String? = nil, accessTokenBasicAuthentification: Bool = false, completionHandler completion: @escaping OAuthSwift.TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
         var parameters = parameters ?? OAuthSwift.Parameters()
         parameters["client_id"] = self.credential.consumerKey
-        parameters["client_secret"] = self.credential.consumerSecret
         parameters["refresh_token"] = refreshToken
         parameters["grant_type"] = "refresh_token"
+		
+		// Omit the consumer secret if it's empty, thereby mimicking the behavior PKCE authentication flow.
+		if self.credential.consumerSecret != "" {
+            parameters["client_secret"] = self.credential.consumerSecret
+        }
+		
         OAuthSwift.log?.trace("Renew access token, parameters: \(parameters)")
         return requestOAuthAccessToken(accessTokenUrl: accessTokenUrl, withParameters: parameters, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, completionHandler: completion)
     }

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -192,16 +192,19 @@ open class OAuthSwiftClient: NSObject {
     // MARK: Refresh Token
     @discardableResult
     open func renewAccessToken(accessTokenUrl: URLConvertible?, withRefreshToken refreshToken: String, parameters: OAuthSwift.Parameters? = nil, headers: OAuthSwift.Headers? = nil, contentType: String? = nil, accessTokenBasicAuthentification: Bool = false, completionHandler completion: @escaping OAuthSwift.TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
+        // The current access token isn't needed anymore.
+        self.credential.oauthToken = ""
+
         var parameters = parameters ?? OAuthSwift.Parameters()
         parameters["client_id"] = self.credential.consumerKey
         parameters["refresh_token"] = refreshToken
         parameters["grant_type"] = "refresh_token"
-		
+
 		// Omit the consumer secret if it's empty; this makes token renewal consistent with PKCE authorization.
 		if !self.credential.consumerSecret.isEmpty {
             parameters["client_secret"] = self.credential.consumerSecret
         }
-		
+
         OAuthSwift.log?.trace("Renew access token, parameters: \(parameters)")
         return requestOAuthAccessToken(accessTokenUrl: accessTokenUrl, withParameters: parameters, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, completionHandler: completion)
     }

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -197,8 +197,8 @@ open class OAuthSwiftClient: NSObject {
         parameters["refresh_token"] = refreshToken
         parameters["grant_type"] = "refresh_token"
 		
-		// Omit the consumer secret if it's empty, thereby mimicking the behavior PKCE authentication flow.
-		if self.credential.consumerSecret != "" {
+		// Omit the consumer secret if it's empty; this makes token renewal consistent with PKCE authorization.
+		if !self.credential.consumerSecret.isEmpty {
             parameters["client_secret"] = self.credential.consumerSecret
         }
 		


### PR DESCRIPTION
This MR fixes a few issues I've come across while interacting with AWS Cognito with a PKCE flow.

First, this fixes the [Allow omitting client_secret when refreshing token obtained via PKCE](https://github.com/OAuthSwift/OAuthSwift/issues/625) issue. In PKCE flows, there is no client secret, so it doesn't make sense to send it to the authorization server. The client secret is currently omitted when obtaining the initial access token, but not when refreshing it.

Second, this change prevents the current (expired) access token from being sent in the refresh token request, which causes AWS Cognito to reject the request. Plus, as a matter of logic, it doesn't make much sense to send an expired token to an authorization server.