### PR TITLE
Restore lint-ability to OAuthSwift Podspec

### DIFF
--- a/OAuthSwift.podspec
+++ b/OAuthSwift.podspec
@@ -9,6 +9,9 @@ Pod::Spec.new do |s|
     'Dongri Jin' => 'dongrify@gmail.com',
     'Eric Marchand' => 'eric.marchand.n7@gmail.com'
   }
+  s.weak_frameworks = 'AuthenticationServices'
+  s.ios.frameworks = 'SafariServices'
+  s.osx.frameworks = 'SafariServices'
   s.source = { git: 'https://github.com/OAuthSwift/OAuthSwift.git', tag: s.version }
   s.source_files = 'Sources/**/*.swift'
   s.swift_versions = ['5.0', '5.1']

--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2019 Dongri Jin, Marchand Eric. All rights reserved.
 //
 
-import Foundation
-#if os(iOS)
-import SafariServices
-#if canImport(AuthenticationServices)
-import AuthenticationServices
-#endif
+#if targetEnvironment(macCatalyst) || os(iOS)
 
-@available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *)
+import AuthenticationServices
+import Foundation
+
+
+@available(iOS 13.0, macCatalyst 13.0, *)
 open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
     var webAuthSession: ASWebAuthenticationSession!
     let prefersEphemeralWebBrowserSession: Bool
@@ -56,12 +55,11 @@ open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
     }
 }
 
-@available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *)
+@available(iOS 13.0, macCatalyst 13.0, *)
 extension ASWebAuthenticationURLHandler {
     static func isCancelledError(domain: String, code: Int) -> Bool {
         return domain == ASWebAuthenticationSessionErrorDomain &&
             code == ASWebAuthenticationSessionError.canceledLogin.rawValue
     }
 }
-
 #endif

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -137,28 +137,18 @@ open class OAuth2Swift: OAuthSwift {
                     let codeString = responseParameters["error_code"],
                     let code = Int(codeString) {
 
-#if targetEnvironment(macCatalyst)
-					if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *),
-                        ASWebAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
-                        completion(.failure(.cancelled))
-                    } else {
-                        otherErrorBlock()
-                    }
-#else
-                    
-#if os(macOS)
-                    otherErrorBlock()
-#else
-                    if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *),
+#if targetEnvironment(macCatalyst) || os(iOS)
+                    if #available(iOS 13.0, macCatalyst 13.0, *),
                         ASWebAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
                         completion(.failure(.cancelled))
                     } else if #available(iOS 11, *),
-                        SFAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
+                              SFAuthenticationURLHandler.isCancelledError(domain: domain, code: code) {
                         completion(.failure(.cancelled))
                     } else {
                         otherErrorBlock()
                     }
-#endif
+#else
+                    otherErrorBlock()
 #endif
                 } else {
                     otherErrorBlock()


### PR DESCRIPTION
Background:
The podspec definition on the main branch lists support for iOS, watchOS, tvOS, macOS  but if one creates a target (as CocoaPods does during lint) for watchOS or tvOS, it can be seen that ASWebAuthenticationURLHandler isn't supported on those platforms. 

Because of how the conditional compilation was written - (nested `#if `) the entire class is actually only available on iOS currently. It would appear that the dependency ASWebAuthenticationURLHandler has on ASWebAuthenticationSession is available for macCatalyst targets, however, and I've left that intact. 

The Podspec is also failing to list its system framework dependencies. For iOS 9..<12 targets,  OAuthSwift depends on SafariServices, and on 12+, it also depends on AuthenticationServices. I've added those to the Podspec. 


With these changes - the pod can be pushed to specs and will succeed to lint. 

Thank you for contributing to OSS and taking time to review this diff. 

Related issues: 
https://github.com/OAuthSwift/OAuthSwift/issues/615

