### PR TITLE
🚨 Fix warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Podfile.lock
 
 # Carthage
 Carthage/
+
+# SwiftPM
+.build/
+.swiftpm/

--- a/Sources/Handler/OAuthWebViewController.swift
+++ b/Sources/Handler/OAuthWebViewController.swift
@@ -20,7 +20,7 @@ import Foundation
 #endif
 
 /// Delegate for OAuthWebViewController
-public protocol OAuthWebViewControllerDelegate: class {
+public protocol OAuthWebViewControllerDelegate: AnyObject {
 
     #if os(iOS) || os(tvOS)
     /// Did web view presented (work only without navigation controller)


### PR DESCRIPTION
This is a new warning in Xcode 12.5.

> OAuthWebViewController.swift:23:49: Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead