### PR TITLE
🐛 Add colon after scheme in error redirect URL

### DIFF
--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -36,7 +36,7 @@ open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
                     let msg = error.localizedDescription.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
                     let errorDomain = (error as NSError).domain
                     let errorCode = (error as NSError).code
-                    let urlString = "\(self.callbackUrlScheme)?error=\(msg ?? "UNKNOWN")&error_domain=\(errorDomain)&error_code=\(errorCode)"
+                    let urlString = "\(self.callbackUrlScheme):?error=\(msg ?? "UNKNOWN")&error_domain=\(errorDomain)&error_code=\(errorCode)"
                     let url = URL(string: urlString)!
                     #if !OAUTH_APP_EXTENSIONS
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
Added a colon after the custom URL scheme given to `ASWebAuthenticationURLHandler`. This scheme is relayed to the [`ASWebAuthenticationSession` constructor](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/2990952-init), but is also used to build a redirect URL when there is an error returned to the `completionHandler`. While the resulting `urlString` creates a valid URL, this URL can't be opened by UIKit without this colon.

Fixes #653 