### PR TITLE
optionally change authorize url param names

### DIFF
--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -19,6 +19,12 @@ open class OAuth1Swift: OAuthSwift {
 
     /// Optionally add consumer key to authorize Url (default: false)
     open var addConsumerKeyToAuthorizeURL: Bool = false
+    
+    /// Optionally change the standard `oauth_token` param name of the authorize Url
+    open var authorizeURLOAuthTokenParam: String = "oauth_token"
+    
+    /// Optionally change the standard `oauth_consumer_key` param name of the authorize Url
+    open var authorizeURLConsumerKeyParam: String = "oauth_consumer_key"
 
     /// Encode token using RFC3986
     open var useRFC3986ToEncodeToken: Bool = false
@@ -108,9 +114,9 @@ open class OAuth1Swift: OAuthSwift {
                 // 2. Authorize
                 if let token = self.encode(token: credential.oauthToken) {
                     var urlString = self.authorizeUrl + (self.authorizeUrl.contains("?") ? "&" : "?")
-                    urlString += "oauth_token=\(token)"
+                    urlString += "\(self.authorizeURLOAuthTokenParam)=\(token)"
                     if self.addConsumerKeyToAuthorizeURL {
-                        urlString += "&oauth_consumer_key=\(self.consumerKey)"
+                        urlString += "&\(self.authorizeURLConsumerKeyParam)=\(self.consumerKey)"
                     }
                     if self.addCallbackURLToAuthorizeURL {
                         urlString += "&oauth_callback=\(callbackURL.absoluteString)"


### PR DESCRIPTION
@phimage you were right to reject my original pull request. It's was dumb on my part.

Your solution is better and did help in part. However it didn't allowed me to change the name of the params in the authorize url.

The idea is that instead of having the standard param names:
`https://www.someprovider.com/authorize?oauth_token=<token>&oauth_consumer_key=<key>`
You can change them to:
`https://www.someprovider.com/authorize?token=<token>&key=<key>`
which is how E*Trade requires it to be.

Thanks for your help!