### PR TITLE
🐛 Encode signature parameters when using PLAINTEXT format

### DIFF
--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -11,7 +11,6 @@
 import AuthenticationServices
 import Foundation
 
-
 @available(iOS 13.0, macCatalyst 13.0, *)
 open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
     var webAuthSession: ASWebAuthenticationSession!

--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -19,10 +19,10 @@ open class OAuth1Swift: OAuthSwift {
 
     /// Optionally add consumer key to authorize Url (default: false)
     open var addConsumerKeyToAuthorizeURL: Bool = false
-    
+
     /// Optionally change the standard `oauth_token` param name of the authorize Url
     open var authorizeURLOAuthTokenParam: String = "oauth_token"
-    
+
     /// Optionally change the standard `oauth_consumer_key` param name of the authorize Url
     open var authorizeURLConsumerKeyParam: String = "oauth_consumer_key"
 

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -402,7 +402,7 @@ open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
         let encodedURL = url.absoluteString.urlEncoded
 
         guard self.signatureMethod != .PLAINTEXT else {
-            return "\(consumerSecret)&\(oauthTokenSecret)"
+            return "\(encodedConsumerSecret)&\(encodedTokenSecret)"
         }
 
         let signatureBaseString = "\(method)&\(encodedURL)&\(encodedParameterString)"

--- a/Sources/OAuthSwiftHTTPRequest.swift
+++ b/Sources/OAuthSwiftHTTPRequest.swift
@@ -151,7 +151,7 @@ open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
                 userInfo["Response-Headers"] = response.allHeaderFields
             }
             let error = NSError(domain: OAuthSwiftError.Domain, code: badRequestCode, userInfo: userInfo)
-            completion?(.failure(.requestError(error:error, request: request)))
+            completion?(.failure(.requestError(error: error, request: request)))
             return
         }
 


### PR DESCRIPTION
Handling for the PLAINTEXT signature format  was added in #623. However, the values used were *not* the `urlEncoded` values and thus could cause issues if one of those values contained unsupported characters.

This PR adds encoding to these values.

## References

RFC-5849 section [3.4.4](https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.4): PLAINTEXT

```
   The "PLAINTEXT" method does not employ a signature algorithm.  It
   MUST be used with a transport-layer mechanism such as TLS or SSL (or
   sent over a secure channel with equivalent protections).  It does not
   utilize the signature base string or the "oauth_timestamp" and
   "oauth_nonce" parameters.

   The "oauth_signature" protocol parameter is set to the concatenated
   value of:

   1.  The client shared-secret, after being encoded (Section 3.6).

   2.  An "&" character (ASCII code 38), which MUST be included even
       when either secret is empty.

   3.  The token shared-secret, after being encoded (Section 3.6).
```

RFC-5849 section [3.6](https://datatracker.ietf.org/doc/html/rfc5849#section-3.6): Percent Encoding

TL;DR: Special URL percent encoding for the Authorization header.

```
   2.  The values are then escaped using the [RFC3986] percent-encoding
       (%XX) mechanism as follows:

       *  Characters in the unreserved character set as defined by
          [RFC3986], Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST
          NOT be encoded.
```