### PR TITLE
👷🏻‍♀️ Run Danger on GitHub Action

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,37 @@
+# https://github.com/marketplace/actions/danger-action
+# https://github.com/MeilCli/danger-action
+# https://github.com/MeilCli/danger-action/releases
+
+name: Danger
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  danger:
+    name: danger
+    runs-on: ubuntu-latest
+    if: github.event_name  == 'pull_request' # if only run pull request when multiple trigger workflow
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }} # change your gemfile path
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - uses: MeilCli/danger-action@v5.4.1
+      with:
+        plugins_file: 'Gemfile'
+        install_path: 'vendor/bundle'
+        danger_file: 'Dangerfile'
+        danger_id: 'danger-pr'
+      env:
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,7 @@ script:
   - xcodebuild -version
   - xcodebuild -showsdks
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Release ONLY_ACTIVE_ARCH=NO build | xcpretty;
-  - export DANGER_GITHUB_API_TOKEN
-  - bundle exec danger
 
 after_success:
    - sleep 10 # Workaround for https://github.com/travis-ci/travis-ci/issues/4725
    - bash <(curl -s https://codecov.io/bash) -J 'OAuthSwift'
-


### PR DESCRIPTION
The Travis build is always blowing up with a "Bad credentials" error. 

> GET https://api.github.com/repos/OAuthSwift/OAuthSwift/pulls/659: 401 - Bad credentials // See: https://docs.github.com/rest (Octokit::Unauthorized)

Not sure how well this is going to work in a GitHub Action workflow, but with the automatic availability of the `GITHUB_TOKEN` for an action, it sure seems simpler to manage.