### PR TITLE
✨ Add Release Drafter action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+#
+# Release Drafter Configuration
+#
+# https://github.com/release-drafter/release-drafter#configuration
+
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '✨ Features'
+    labels:
+      - '🆕 feature request'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - '🐛 bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  # What's New
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,35 @@
+# 
+# Release Drafter Workflow
+# 
+# https://github.com/marketplace/actions/release-drafter
+# https://github.com/release-drafter/release-drafter/releases
+
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5.15.0
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the [Release Drafter](https://github.com/marketplace/actions/release-drafter) action which automatically creates/updates a draft release on merge of each PR. This is essentially an automatic changelog and is quite amazing.

Check out a [preview](https://github.com/mas-cli/mas/pull/324#issuecomment-798999250) of this in action on the [mas](https://github.com/mas-cli/mas) project (we don't have a draft release atm).