### PR TITLE
Added custom log action

### DIFF
--- a/Sources/OAuthLogProtocol.swift
+++ b/Sources/OAuthLogProtocol.swift
@@ -22,6 +22,8 @@ public enum OAuthLogLevel: Int {
 public protocol OAuthLogProtocol {
 
    var level: OAuthLogLevel { get }
+	
+   var logAction: ((_ message: String) -> Void)? { get set }
 
    /// basic level of print messages
    func trace<T>(_ message: @autoclosure () -> T, filename: String, line: Int, function: String)
@@ -39,21 +41,36 @@ extension OAuthLogProtocol {
       let logLevel = OAuthLogLevel.trace
       // deduce based on the current log level vs. globally set level, to print such log or not
       if level.rawValue >= logLevel.rawValue {
-         print("[TRACE] \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
+         let message = "[TRACE] \((filename as NSString).lastPathComponent) [\(line)]: \(message())"
+		 if let action = logAction {
+		    action(message)
+		 } else {
+		    print(message)
+		 }
       }
    }
 
    public func warn<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.warn
       if level.rawValue >= logLevel.rawValue {
-         print("[WARN] \(self) = \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
+         let message = "[WARN] \(self) = \((filename as NSString).lastPathComponent) [\(line)]: \(message())"
+		 if let action = logAction {
+			action(message)
+		 } else {
+			print(message)
+		 }
       }
    }
 
    public func error<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.error
       if level.rawValue >= logLevel.rawValue {
-         print("[ERROR] \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
+         let message = "[ERROR] \((filename as NSString).lastPathComponent) [\(line)]: \(message())"
+		 if let action = logAction {
+			action(message)
+		 } else {
+			print(message)
+		 }
       }
 
    }
@@ -61,6 +78,7 @@ extension OAuthLogProtocol {
 
 public struct OAuthDebugLogger: OAuthLogProtocol {
    public let level: OAuthLogLevel
+   public var logAction: ((_ message: String) -> Void)? = nil
    init(_ level: OAuthLogLevel) {
       self.level = level
    }

--- a/Sources/OAuthSwift.swift
+++ b/Sources/OAuthSwift.swift
@@ -122,4 +122,14 @@ extension OAuthSwift {
       Self.log = OAuthDebugLogger(level)
       OAuthSwift.log?.trace("Logging enabled with level: \(level)")
    }
+
+   /// Set a custom log action to preform instead of printing to the console
+   /// Used to integrate external logging systems
+   public static func setCustomLogAction(_ action: ((_ message: String) -> Void)?) {
+      if Self.log == nil {
+         self.setLogLevel(.error)
+      }
+      Self.log?.logAction = action
+      OAuthSwift.log?.trace("Custom log action enabled with level: \(Self.log!.level)")
+   }
 }


### PR DESCRIPTION
The new logging mechanism looks really useful, however, I wanted to extend it to integrate with my app's existing logging system. I added a custom log action that accepts a closure, and the log action is used instead of just printing to the console so the actual log can be customized.

This extends the work done by @svoip and the logging system.

In order to use this new functionality, you would add something like this:

```swift
OAuthSwift.setLogLevel(.trace)
OAuthSwift.setCustomLogAction { message in
   CustomLogger("[OAUTHSWIFT] \(message)")
}
```