### PR TITLE
Fixes OAuthSwift/OAuthSwift/issues/669

### DIFF
--- a/Sources/Handler/ASWebAuthenticationURLHandler.swift
+++ b/Sources/Handler/ASWebAuthenticationURLHandler.swift
@@ -12,6 +12,7 @@ import AuthenticationServices
 import Foundation
 
 @available(iOS 13.0, macCatalyst 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
     var webAuthSession: ASWebAuthenticationSession!
     let prefersEphemeralWebBrowserSession: Bool
@@ -55,6 +56,7 @@ open class ASWebAuthenticationURLHandler: OAuthSwiftURLHandlerType {
 }
 
 @available(iOS 13.0, macCatalyst 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 extension ASWebAuthenticationURLHandler {
     static func isCancelledError(domain: String, code: Int) -> Bool {
         return domain == ASWebAuthenticationSessionErrorDomain &&

--- a/Sources/Handler/OAuthSwiftOpenURLExternally.swift
+++ b/Sources/Handler/OAuthSwiftOpenURLExternally.swift
@@ -17,6 +17,7 @@ import AppKit
 #endif
 
 /// Open externally using open url application function.
+@available(iOSApplicationExtension, unavailable)
 open class OAuthSwiftOpenURLExternally: OAuthSwiftURLHandlerType {
 
     public static var sharedInstance: OAuthSwiftOpenURLExternally = OAuthSwiftOpenURLExternally()

--- a/Sources/Handler/OAuthWebViewController.swift
+++ b/Sources/Handler/OAuthWebViewController.swift
@@ -36,6 +36,7 @@ public protocol OAuthWebViewControllerDelegate: AnyObject {
 }
 
 /// A web view controller, which handler OAuthSwift authentification. Must be override to display a web view.
+@available(iOSApplicationExtension, unavailable)
 open class OAuthWebViewController: OAuthViewController, OAuthSwiftURLHandlerType {
 
     #if os(iOS) || os(tvOS) || os(OSX)

--- a/Sources/Handler/SFAuthenticationURLHandler.swift
+++ b/Sources/Handler/SFAuthenticationURLHandler.swift
@@ -15,6 +15,7 @@ import AuthenticationServices
 
 #if !targetEnvironment(macCatalyst)
 @available(iOS, introduced: 11.0, deprecated: 12.0)
+@available(iOSApplicationExtension, unavailable)
 open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
     var webAuthSession: SFAuthenticationSession!
     let callbackUrlScheme: String
@@ -50,6 +51,7 @@ open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
 }
 
 @available(iOS, introduced: 11.0, deprecated: 12.0)
+@available(iOSApplicationExtension, unavailable)
 extension SFAuthenticationURLHandler {
     static func isCancelledError(domain: String, code: Int) -> Bool {
         return domain == SFAuthenticationErrorDomain &&

--- a/Sources/Handler/SafariURLHandler.swift
+++ b/Sources/Handler/SafariURLHandler.swift
@@ -16,6 +16,7 @@ import AuthenticationServices
 #endif
 
 @available(iOS 9.0, *)
+@available(iOSApplicationExtension, unavailable)
 open class SafariURLHandler: NSObject, OAuthSwiftURLHandlerType, SFSafariViewControllerDelegate {
 
     public typealias UITransion = (_ controller: SFSafariViewController, _ handler: SafariURLHandler) -> Void

--- a/Sources/NSError+OAuthSwift.swift
+++ b/Sources/NSError+OAuthSwift.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOSApplicationExtension, unavailable)
 public extension NSError {
 
     /// Checks the headers contained in the userInfo whether this error was caused by an 

--- a/Sources/NotificationCenter+OAuthSwift.swift
+++ b/Sources/NotificationCenter+OAuthSwift.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 
+@available(iOSApplicationExtension, unavailable)
 public extension Notification.Name {
     @available(*, deprecated, renamed: "OAuthSwift.didHandleCallbackURL")
     static let OAuthSwiftHandleCallbackURL: Notification.Name = OAuthSwift.didHandleCallbackURL
 }
+@available(iOSApplicationExtension, unavailable)
 public extension OAuthSwift {
     static let didHandleCallbackURL: Notification.Name = .init("OAuthSwiftCallbackNotificationName")
 }

--- a/Sources/OAuth1Swift.swift
+++ b/Sources/OAuth1Swift.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOSApplicationExtension, unavailable)
 open class OAuth1Swift: OAuthSwift {
 
     /// If your oauth provider doesn't provide `oauth_verifier`

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOSApplicationExtension, unavailable)
 open class OAuth2Swift: OAuthSwift {
 
     /// If your oauth provider need to use basic authentification

--- a/Sources/OAuthSwift.swift
+++ b/Sources/OAuthSwift.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(iOSApplicationExtension, unavailable)
 open class OAuthSwift: NSObject, OAuthSwiftRequestHandle {
 
     // MARK: Properties
@@ -18,6 +19,7 @@ open class OAuthSwift: NSObject, OAuthSwiftRequestHandle {
     open var version: OAuthSwiftCredential.Version { return self.client.credential.version }
 
     /// Handle the authorize url into a web view or browser
+    @available(iOSApplicationExtension, unavailable)
     open var authorizeURLHandler: OAuthSwiftURLHandlerType = OAuthSwiftURLHandlerTypeFactory.default
 
     fileprivate var currentRequests: [String: OAuthSwiftRequestHandle] = [:]
@@ -99,6 +101,7 @@ open class OAuthSwift: NSObject, OAuthSwiftRequestHandle {
 }
 
 // MARK: - alias
+@available(iOSApplicationExtension, unavailable)
 extension OAuthSwift {
 
     public typealias Parameters = [String: Any]
@@ -112,6 +115,7 @@ extension OAuthSwift {
 }
 
 // MARK: - Logging
+@available(iOSApplicationExtension, unavailable)
 extension OAuthSwift {
 
    static var log: OAuthLogProtocol?

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -14,6 +14,7 @@ public var OAuthSwiftDataEncoding: String.Encoding = .utf8
     func cancel()
 }
 
+@available(iOSApplicationExtension, unavailable)
 open class OAuthSwiftClient: NSObject {
 
     fileprivate(set) open var credential: OAuthSwiftCredential

--- a/Sources/OAuthSwiftCredential.swift
+++ b/Sources/OAuthSwiftCredential.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// Allow to customize computed headers
+@available(iOSApplicationExtension, unavailable)
 public protocol OAuthSwiftCredentialHeadersFactory {
     func make(_ url: URL, method: OAuthSwiftHTTPRequest.Method, parameters: OAuthSwift.Parameters, body: Data?) -> [String: String]
 }
@@ -40,6 +41,7 @@ public enum OAuthSwiftHashMethod: String {
 }
 
 /// The credential for authentification
+@available(iOSApplicationExtension, unavailable)
 open class OAuthSwiftCredential: NSObject, NSSecureCoding, Codable {
 
     public static let supportsSecureCoding = true

--- a/Sources/OAuthSwiftError.swift
+++ b/Sources/OAuthSwiftError.swift
@@ -125,6 +125,7 @@ extension OAuthSwiftError: CustomStringConvertible {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 extension OAuthSwift {
     static func retainError(_ completionHandler: OAuthSwiftHTTPRequest.CompletionHandler?) {
         #if !OAUTH_NO_RETAIN_ERROR

--- a/Sources/OAuthSwiftHTTPRequest.swift
+++ b/Sources/OAuthSwiftHTTPRequest.swift
@@ -15,6 +15,7 @@ import UIKit
 
 let kHTTPHeaderContentType = "Content-Type"
 
+@available(iOSApplicationExtension, unavailable)
 open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
 
     // Using NSLock for Linux compatible locking 
@@ -308,6 +309,7 @@ open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
 }
 
 // MARK: - Request configuraiton
+@available(iOSApplicationExtension, unavailable)
 extension OAuthSwiftHTTPRequest {
 
     /// Configuration for request
@@ -454,6 +456,7 @@ public struct URLSessionFactory {
 
 // MARK: - status code mapping
 
+@available(iOSApplicationExtension, unavailable)
 extension OAuthSwiftHTTPRequest {
 
     class func descriptionForHTTPStatus(_ status: Int, responseString: String) -> String {

--- a/Sources/OAuthSwiftURLHandlerType.swift
+++ b/Sources/OAuthSwiftURLHandlerType.swift
@@ -24,5 +24,6 @@ import AppKit
 
 public struct OAuthSwiftURLHandlerTypeFactory {
 
+    @available(iOSApplicationExtension, unavailable)
     static var `default`: OAuthSwiftURLHandlerType = OAuthSwiftOpenURLExternally.sharedInstance
 }

--- a/Sources/String+OAuthSwift.swift
+++ b/Sources/String+OAuthSwift.swift
@@ -109,6 +109,7 @@ extension String {
         return parameters
     }
 
+    @available(iOSApplicationExtension, unavailable)
     public var headerDictionary: OAuthSwift.Headers {
         return dictionaryBySplitting(",", keyValueSeparator: "=")
     }

--- a/Sources/UIApplication+OAuthSwift.swift
+++ b/Sources/UIApplication+OAuthSwift.swift
@@ -9,6 +9,7 @@
 #if os(iOS) || os(tvOS)
     import UIKit
 
+    @available(iOSApplicationExtension, unavailable)
     extension UIApplication {
         @nonobjc static var topViewController: UIViewController? {
             #if !OAUTH_APP_EXTENSIONS


### PR DESCRIPTION
This PR addresses a build error which appears to be caused by a change introduced in Xcode 13 beta 3:

> Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)

I tried to keep the scope as limited as possible, and tested as much as I could and I don't think it broke anything, but it is definitely possible that I missed something. It is my first contribution to an open source project so I'm happy to take any feedback and implement changes. Just let me know. Thanks!