### PR TITLE
Open external URL from main thread

### DIFF
--- a/Sources/Handler/OAuthSwiftOpenURLExternally.swift
+++ b/Sources/Handler/OAuthSwiftOpenURLExternally.swift
@@ -22,18 +22,20 @@ open class OAuthSwiftOpenURLExternally: OAuthSwiftURLHandlerType {
     public static var sharedInstance: OAuthSwiftOpenURLExternally = OAuthSwiftOpenURLExternally()
 
     @objc open func handle(_ url: URL) {
-        #if os(iOS) || os(tvOS)
-        #if !OAUTH_APP_EXTENSIONS
-        if #available(iOS 10.0, tvOS 10.0, *) {
-            UIApplication.shared.open(url)
-        } else {
-            UIApplication.shared.openURL(url)
+        DispatchQueue.main.async {
+            #if os(iOS) || os(tvOS)
+            #if !OAUTH_APP_EXTENSIONS
+            if #available(iOS 10.0, tvOS 10.0, *) {
+                UIApplication.shared.open(url)
+            } else {
+                UIApplication.shared.openURL(url)
+            }
+            #endif
+            #elseif os(watchOS)
+            // WATCHOS: not implemented
+            #elseif os(OSX)
+            NSWorkspace.shared.open(url)
+            #endif
         }
-        #endif
-        #elseif os(watchOS)
-        // WATCHOS: not implemented
-        #elseif os(OSX)
-        NSWorkspace.shared.open(url)
-        #endif
     }
 }


### PR DESCRIPTION
Currently it is possible that UIApplication.open(url) is run from a background thread. This causes the app to hang for a while before opening the external browser, and Xcode also shows a warning (see image below).
This change makes sure that this is always run from main thread, clearing the Xcode warning and the delay in the app.

I only tested this on iOS 14 (line 29 of file), but I imagine it works for the other lines as well.

<img width="1213" alt="Screen Shot 2021-08-17 at 11 15 59 AM" src="https://user-images.githubusercontent.com/13061863/129757406-7844657d-730a-4ca6-a10b-60df1b3e75a0.png">
