### PR TITLE
Fix parsing Withings new response format Fix OAuthSwift/OAuthSwift#663

### DIFF
--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -225,7 +225,11 @@ open class OAuthSwiftClient: NSObject {
                 let responseParameters: OAuthSwift.Parameters
 
                 if let jsonDico = responseJSON as? [String: Any] {
-                    responseParameters = jsonDico
+                    if let withingsParameters = jsonDico["body"] as? [String: Any] { // withings parameters are nested in `body`
+                        responseParameters = withingsParameters
+                    } else {
+                        responseParameters = jsonDico
+                    }
                 } else {
                     responseParameters = response.string?.parametersFromQueryString ?? [:]
                 }


### PR DESCRIPTION
As stated in #663, the new Withings endpoint:

1. requires a parameter `action`, with value "requesttoken";
2. requires parameter `grant_type` to equal "refresh_token" (not "authorization_code");
3. and has the response structured differently: the keys of the response are now just `body` and `status`, with the former keys, including `code`, all in an object down below `body`.

**Description code change:**
This PR addresses nr.3, because nr.1 and 2 don't need code modifications (see below).
The provided solution extracts the response parameters if the response dictionary contains a key `body`. To my knowledge, only Withings uses this particular response format.

**Requirement nr.1:**
To mitigate requirement nr.1, the user can append the `accessTokenUrl` with `?action=requesttoken`, i.e.:
```swift
oauthswift = OAuth2Swift(
    consumerKey:    "********",
    consumerSecret: "********",
    authorizeUrl:   "https://account.withings.com/oauth2_user/authorize2",
    accessTokenUrl: "https://wbsapi.withings.net/v2/oauth2?action=requesttoken",
    responseType:   "code"
)
```
This is more of a workaround, but it works. As such, no modifications are needed in the source code. An alternative would be to introduce a boolean, specifically to accommodate Withings. My preference is to omit such special cases as much as possible. But please give feedback if this workaround is not preferred. 

**Requirement nr.2:**
Requirement nr.2 is already implemented, and doesn't need any changes: https://github.com/OAuthSwift/OAuthSwift/blob/d85964b96dbce94df961f28b996187c835089903/Sources/OAuthSwiftClient.swift#L201

I have tested it, and with these changes, I can successfully authorize with Withings and can also refresh the token.