### PR TITLE
Fix "unowned self" that can cause crash

### DIFF
--- a/Sources/Handler/OAuthWebViewController.swift
+++ b/Sources/Handler/OAuthWebViewController.swift
@@ -136,8 +136,8 @@ open class OAuthWebViewController: OAuthViewController, OAuthSwiftURLHandlerType
         OAuthSwift.log?.trace("OAuthWebViewController: dismiss view controller")
 
         #if os(iOS) || os(tvOS)
-            let completion: () -> Void = { [unowned self] in
-                self.delegate?.oauthWebViewControllerDidDismiss()
+            let completion: () -> Void = { [weak self] in
+                self?.delegate?.oauthWebViewControllerDidDismiss()
             }
             if let navigationController = self.navigationController, (!useTopViewControlerInsteadOfNavigation || self.topViewController == nil) {
                 navigationController.popViewController(animated: dismissViewControllerAnimated)


### PR DESCRIPTION
With an `unowned self` the reference to self can become nil without the ability for the code to be aware. As such, `unowned self` should be used when we know something else is guaranteed to retain a reference to our self. In this case there is no such guarantee. Fortunately, we can use a `weak self` to have nullability safety here without any performance
concerns.

This was noticed when it caused a crash in our app due to a particular series of events which resulted in this getting called after we had already gotten rid of the OAuthWebViewController.

Thank you, and thanks for OAuthSwift!