### PR TITLE
Improvements to `requestWithAutomaticAccessTokenRenewal`

### DIFF
--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -308,38 +308,27 @@ open class OAuthSwiftClient: NSObject {
                 return
             }
 
-            switch result {
-            case .success(let response):
+            guard case .failure(let error) = result,
+                  case .tokenExpired = error else {
                 if let completion = completion {
-                    completion(.success(response))
+                    completion(result)
+                }
+                return
+            }
+
+            this.renewAccessToken(accessTokenUrl: accessTokenUrl, withRefreshToken: this.credential.oauthRefreshToken, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification) { [weak self] result in
+                guard let this = self else {
+                    OAuthSwift.retainError(completion)
+                    return
                 }
 
-            case .failure(let error):
-                switch error {
-                case OAuthSwiftError.tokenExpired:
-                    if let onTokenRenewal = onTokenRenewal {
-                        let renewCompletionHandler: OAuthSwift.TokenCompletionHandler = { result in
-                            switch result {
-                            case .success(let (credential, _, _)):
-                                onTokenRenewal(.success(credential))
-                                this.requestWithAutomaticAccessTokenRenewal(url: url, method: method, parameters: parameters, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, accessTokenUrl: accessTokenUrl, onTokenRenewal: nil, completionHandler: completion)
-                            case .failure(let error):
-                                if let completion = completion {
-                                    completion(.failure(.tokenExpired(error: error)))
-                                }
-                            }
-                        }
-
-                        _ = this.renewAccessToken(accessTokenUrl: accessTokenUrl, withRefreshToken: this.credential.oauthRefreshToken, headers: headers, contentType: contentType, accessTokenBasicAuthentification: accessTokenBasicAuthentification, completionHandler: renewCompletionHandler)
-                    } else {
-                        if let completion = completion {
-                            completion(.failure(.tokenExpired(error: nil)))
-                        }
-                    }
-
-                default:
+                switch result {
+                case .success(let (credential, _, _)):
+                    onTokenRenewal?(.success(credential))
+                    this.request(url, method: method, parameters: parameters, headers: headers, completionHandler: completion)
+                case .failure(let error):
                     if let completion = completion {
-                        completion(.failure(.tokenExpired(error: nil)))
+                        completion(.failure(.tokenExpired(error: error)))
                     }
                 }
             }


### PR DESCRIPTION
This fixes error handling, and makes a couple of improvements to implementation of the `requestWithAutomaticAccessTokenRenewal` function:

- Pass all error responses as-is, and look only for the `tokenExpired`;
- Treat `onTokenRenewal` parameter as truly optional - perform the token renewal even if `onTokenRenewal` is `nil`;
- Do not keep a strong reference to `self` in the completion block for `renewAccessToken` call.

The main issue I had was that `requestWithAutomaticAccessTokenRenewal` would swallow all errors and convert them to the empty `tokenExpired` errors, preventing any possibility of implementing custom error handling logic on the client side:

```
completion(.failure(.tokenExpired(error: nil)))
```