### PR TITLE
Fix reversed log level check.

### DIFF
--- a/Sources/OAuthLogProtocol.swift
+++ b/Sources/OAuthLogProtocol.swift
@@ -38,21 +38,21 @@ extension OAuthLogProtocol {
    public func trace<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.trace
       // deduce based on the current log level vs. globally set level, to print such log or not
-      if level.rawValue >= logLevel.rawValue {
+      if level.rawValue <= logLevel.rawValue {
          print("[TRACE] \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
       }
    }
 
    public func warn<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.warn
-      if level.rawValue >= logLevel.rawValue {
+      if level.rawValue <= logLevel.rawValue {
          print("[WARN] \(self) = \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
       }
    }
 
    public func error<T>(_ message: @autoclosure () -> T, filename: String = #file, line: Int = #line, function: String = #function) {
       let logLevel = OAuthLogLevel.error
-      if level.rawValue >= logLevel.rawValue {
+      if level.rawValue <= logLevel.rawValue {
          print("[ERROR] \((filename as NSString).lastPathComponent) [\(line)]: \(message())")
       }
 


### PR DESCRIPTION
Messages for a higher log level than the set log level were not logged due to inverted logic.