### PR TITLE
Remove showing the network activity status, deprecated sind iOS 13

### DIFF
--- a/Sources/OAuthSwiftHTTPRequest.swift
+++ b/Sources/OAuthSwiftHTTPRequest.swift
@@ -102,27 +102,11 @@ open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
 
             self.task?.resume()
             self.session.finishTasksAndInvalidate()
-
-            #if os(iOS)
-                #if !OAUTH_APP_EXTENSIONS
-                #if !targetEnvironment(macCatalyst)
-                    UIApplication.shared.isNetworkActivityIndicatorVisible = self.config.sessionFactory.isNetworkActivityIndicatorVisible
-                    #endif
-                #endif
-            #endif
         }
     }
 
     /// Function called when receiving data from server.
     public static func completionHandler(completionHandler completion: CompletionHandler?, request: URLRequest, data: Data?, resp: URLResponse?, error: Error?) {
-        #if os(iOS)
-        #if !OAUTH_APP_EXTENSIONS
-        #if !targetEnvironment(macCatalyst)
-        UIApplication.shared.isNetworkActivityIndicatorVisible = false
-        #endif
-        #endif
-        #endif
-
         // MARK: failure error returned by server
         if let error = error {
             var oauthError: OAuthSwiftError = .requestError(error: error, request: request)


### PR DESCRIPTION
This change removes changing the network activity indicator as the necessary api has been marked as deprecated in iOS 13.

Besides the old solution was not safely being called on the main thread, the `OAUTH_APP_EXTENSIONS` build flag is of no use when being used as a swift package.