### PR TITLE
Remove usage of SFAuthenticationErrorDomain to avoid getting app rejection

### DIFF
--- a/Sources/Handler/SFAuthenticationURLHandler.swift
+++ b/Sources/Handler/SFAuthenticationURLHandler.swift
@@ -52,8 +52,7 @@ open class SFAuthenticationURLHandler: OAuthSwiftURLHandlerType {
 @available(iOS, introduced: 11.0, deprecated: 12.0)
 extension SFAuthenticationURLHandler {
     static func isCancelledError(domain: String, code: Int) -> Bool {
-        return domain == SFAuthenticationErrorDomain &&
-            code == SFAuthenticationError.canceledLogin.rawValue
+        code == SFAuthenticationError.canceledLogin.rawValue
     }
 }
 #endif


### PR DESCRIPTION
One of our apps recently received a rejection from Apple because to the usage of `_SFAuthenticationErrorDomain`, which is now considered a private API after being deprecated in iOS 12.0. The rejection included the following message:

> ITMS-90338: Non-public API usage - The app references non-public symbols in <APP_NAME>: _SFAuthenticationErrorDomain. If method names in your source code match the private Apple APIs listed above, altering your method names will help prevent this app from being flagged in future submissions. In addition, note that one or more of the above APIs may be located in a static library that was included with your app. If so, they must be removed. For further information, visit the Technical Support Information at http://developer.apple.com/support/technical/

In this PR, I am proposing to remove the usage of `SFAuthenticationErrorDomain` to avoid getting the app rejection. However, it's perhaps a good time to drop the support for `SFAuthenticationSession` support altogether from OAuthSwift with a major version change of `OAuthSwift` since it has been deprecated for ~4 years. But I will leave that to a separate discussion topic.