### PR TITLE
Improved error information

### DIFF
--- a/Sources/OAuthSwiftHTTPRequest.swift
+++ b/Sources/OAuthSwiftHTTPRequest.swift
@@ -164,11 +164,20 @@ open class OAuthSwiftHTTPRequest: NSObject, OAuthSwiftRequestHandle {
                 NSLocalizedDescriptionKey: localizedDescription,
                 "Response-Headers": response.allHeaderFields,
                 OAuthSwiftError.ResponseKey: response,
-                OAuthSwiftError.ResponseDataKey: responseData
+                OAuthSwiftError.ResponseDataKey: responseData,
+                "Request": request,
+                "Request-Method": request.httpMethod ?? "nil",
+                "Request-Headers": request.allHTTPHeaderFields ?? "nil"
+                
             ]
+            
+            if let requestData = request.httpBody, let requestString = String(data: requestData, encoding: .utf8) {
+                userInfo["Request-Body"] = requestString
+            }
             if let string = responseString {
                 userInfo["Response-Body"] = string
             }
+            
             if let urlString = response.url?.absoluteString {
                 userInfo[NSURLErrorFailingURLErrorKey] = urlString
             }


### PR DESCRIPTION
I was recently debugging OAuth server side issues and the error message did not contain all infos I needed to send to the server team: detailed information about the request was missing. I have modified the error creation so that it includes this info as well.

