### PR TITLE
feat: Include error description for server errors

### DIFF
--- a/OAuthSwiftTests/OAuthSwiftErrorTest.swift
+++ b/OAuthSwiftTests/OAuthSwiftErrorTest.swift
@@ -83,7 +83,7 @@ class OAuthSwiftErrorTest: XCTestCase {
      testOAuthSwiftError(.tokenExpired)
      testOAuthSwiftError(.missingState)
      testOAuthSwiftError(.stateNotEqual(state: "state", responseState: "responseState"))
-     testOAuthSwiftError(.serverError(message: "message"))
+     testOAuthSwiftError(.serverError(message: "message", description: "description"))
      testOAuthSwiftError(.encodingError(urlString: "urlString"))
      testOAuthSwiftError(.authorizationPending)
      testOAuthSwiftError(.requestCreation(message: "message"))

--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -165,12 +165,12 @@ open class OAuth2Swift: OAuthSwift {
                     let description = responseParameters["error_description"] ?? ""
                     let message = NSLocalizedString(error, comment: description)
                     OAuthSwift.log?.error("Authorization failed with: \(description)")
-                    completion(.failure(.serverError(message: message)))
+                    completion(.failure(.serverError(message: message, description: description)))
                 }
             } else {
                 let message = "No access_token, no code and no error provided by server"
                 OAuthSwift.log?.error("Authorization failed with: \(message)")
-                completion(.failure(.serverError(message: message)))
+                completion(.failure(.serverError(message: message, description: "")))
             }
         }
 

--- a/Sources/OAuthSwiftClient.swift
+++ b/Sources/OAuthSwiftClient.swift
@@ -256,7 +256,7 @@ open class OAuthSwiftClient: NSObject {
                 guard let accessToken = responseParameters["access_token"] as? String else {
                     let message = NSLocalizedString("Could not get Access Token", comment: "Due to an error in the OAuth2 process, we couldn't get a valid token.")
                     OAuthSwift.log?.error("Could not get access token")
-                    completion(.failure(.serverError(message: message)))
+                    completion(.failure(.serverError(message: message, description: "")))
                     return
                 }
 

--- a/Sources/OAuthSwiftError.swift
+++ b/Sources/OAuthSwiftError.swift
@@ -18,7 +18,7 @@ public enum OAuthSwiftError: Error {
     /// Returned state value is wrong
     case stateNotEqual(state: String, responseState: String)
     /// Error from server
-    case serverError(message: String)
+    case serverError(message: String, description: String)
     /// Failed to create URL \(urlString) not convertible to URL, please encode
     case encodingError(urlString: String)
     /// Failed to create request with \(urlString)
@@ -94,7 +94,7 @@ public enum OAuthSwiftError: Error {
 
     public var underlyingMessage: String? {
         switch self {
-        case .serverError(let m): return m
+        case .serverError(let m, let d): return m
         case .configurationError(let m): return m
         case .requestCreation(let m): return m
         default: return nil
@@ -111,7 +111,7 @@ extension OAuthSwiftError: CustomStringConvertible {
         case .tokenExpired(let e): return "tokenExpired[\(String(describing: e))]"
         case .missingState: return "missingState"
         case .stateNotEqual(let s, let e): return "stateNotEqual[\(s)<>\(e)]"
-        case .serverError(let m): return "serverError[\(m)]"
+        case .serverError(let m, let d): return "serverError[\(m)<>\(d)]"
         case .encodingError(let urlString): return "encodingError[\(urlString)]"
         case .requestCreation(let m): return "requestCreation[\(m)]"
         case .missingToken: return "missingToken"
@@ -149,7 +149,7 @@ extension OAuthSwiftError: CustomNSError {
     public var errorUserInfo: [String: Any] {
         switch self {
         case .configurationError(let m): return ["message": m]
-        case .serverError(let m): return ["message": m]
+        case .serverError(let m, let d): return ["message": m, "description": d]
         case .requestCreation(let m): return ["message": m]
 
         case .tokenExpired(let e): return ["error": e as Any]


### PR DESCRIPTION
I am using Azure AD B2C and I need to be able to handle when the user taps the "Forgot your password?" link. When that is tapped it sends an error back to the app with an error code "AADB2C90118" that I need to look for so I can send them to a page to reset their password. Currently it treats it as a server error and I cannot access the detailed message.