### PR TITLE
Set `requestOAuthAccessToken` function public

### DIFF
--- a/Sources/OAuth2Swift.swift
+++ b/Sources/OAuth2Swift.swift
@@ -253,7 +253,7 @@ open class OAuth2Swift: OAuthSwift {
                                             completionHandler: completion)
     }
 
-    fileprivate func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, customKeypath: String? = nil, completionHandler completion: @escaping TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
+    public func requestOAuthAccessToken(withParameters parameters: OAuthSwift.Parameters, headers: OAuthSwift.Headers? = nil, customKeypath: String? = nil, completionHandler completion: @escaping TokenCompletionHandler) -> OAuthSwiftRequestHandle? {
         return self.client.requestOAuthAccessToken(accessTokenUrl: self.accessTokenUrl, withParameters: parameters,
                                                    headers: headers, contentType: self.contentType,
                                                    accessTokenBasicAuthentification: self.accessTokenBasicAuthentification,


### PR DESCRIPTION
Due to the way our OAuth workflows work I found it necessary to make the function [OAuth2Swift.requestOAuthAccessToken(withParameters...)](https://github.com/OAuthSwift/OAuthSwift/blob/fe6b6a4ccb0f6fba346a06ae34a75b0733afa70d/Sources/OAuth2Swift.swift#L256) public as I need to call it directly.

Is there any issues with making this method public?

